### PR TITLE
Add workflow_jobs_relaunch_create permission to configs

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -47,6 +47,7 @@ categories:
     - controller.jobs_cancel_create
     - controller.workflow_jobs_cancel_create
     - controller.jobs_relaunch_create
+    - controller.workflow_jobs_relaunch_create
     - controller.jobs_list
     - eda.activation_instances_list
     - eda.activation_instances_logs_list

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -33,7 +33,8 @@ data:
         - controller.jobs_job_events_list
         - controller.jobs_cancel_create
         - controller.workflow_jobs_cancel_create
-        - controller.jobs_relaunch_create     
+        - controller.jobs_relaunch_create
+        - controller.workflow_jobs_relaunch_create     
         - controller.jobs_list
         - eda.activation_instances_list
         - eda.activation_instances_logs_list

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -32,6 +32,7 @@ data:
         - controller.jobs_cancel_create
         - controller.workflow_jobs_cancel_create
         - controller.jobs_relaunch_create
+        - controller.workflow_jobs_relaunch_create
         - controller.jobs_list
         - eda.activation_instances_list
         - eda.activation_instances_logs_list


### PR DESCRIPTION
It's included in the "api's by phase" for phase 1 but not included in the "category" for some reason.  Relaunching workflow jobs should be in the same category as relaunching job template jobs.