### PR TITLE
Update System Monitoring Category tool list to better align with user stories

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -66,8 +66,6 @@ categories:
     - controller.groups_create
 
   system_monitoring:
-    - controller.ping_list
-    - controller.config_list
     - controller.instance_groups_list
     - controller.instance_groups_create
     - controller.instance_groups_read
@@ -79,4 +77,5 @@ categories:
     - gateway.http_ports_create
     - controller.activity_stream_list
     - controller.instances_read
+    - gateway.status_retrieve
     - gateway.feature_flags_state_retrieve

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -55,8 +55,6 @@ data:
         # controller: /api/v2/settings/database/
 
       system_monitoring:
-        - controller.ping_list
-        - controller.config_list
         - controller.instance_groups_list
         - controller.instance_groups_create
         - controller.instance_groups_read
@@ -68,6 +66,7 @@ data:
         - gateway.http_ports_create
         - controller.activity_stream_list
         - controller.instances_read
+        - gateway.status_retrieve
         - gateway.feature_flags_state_retrieve
 
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -53,8 +53,6 @@ data:
         # controller: /api/v2/settings/database/
 
       system_monitoring:
-        - controller.ping_list
-        - controller.config_list
         - controller.instance_groups_list
         - controller.instance_groups_create
         - controller.instance_groups_read
@@ -66,6 +64,7 @@ data:
         - gateway.http_ports_create
         - controller.activity_stream_list
         - controller.instances_read
+        - gateway.status_retrieve
         - gateway.feature_flags_state_retrieve
 
       staging:
@@ -407,6 +406,7 @@ data:
         - controller.users_admin_of_organizations_list
         - controller.analytics_reports_list
         - controller.inventories_delete
+        - gateway.status_retrieve
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Upon reviewing the user stories I think the gateway status endpoint is better than controller ping/config for representing the status of each service.  Additionally controller.instance_groups_read is needed to pull capacity information.