### PR TITLE
Update permissions in aap-mcp.sample.yaml

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -89,12 +89,12 @@ categories:
     - gateway.teams_update
     - gateway.teams_destroy
     - gateway.teams_users_list
-    - gateway.teams_users_associate_create
-    - gateway.teams_users_disassociate_create
     - gateway.me_list
     - gateway.role_definitions_list
     - gateway.role_team_assignments_list
     - gateway.role_user_assignments_list
+    - gateway.role_user_assignments_create
+    - gateway.role_user_assignments_destroy
     - gateway.organizations_list
     - gateway.organizations_retrieve
     - gateway.organizations_create


### PR DESCRIPTION
  Removed:
  - gateway.teams_users_associate_create - Old team user association endpoint
  - gateway.teams_users_disassociate_create - Old team user disassociation endpoint

  Added:
  - gateway.role_user_assignments_create - POST to /api/gateway/v1/role_user_assignments/
  - gateway.role_user_assignments_destroy - DELETE on /api/gateway/v1/role_user_assignments/{id}

  This updates the user management to use the proper RBAC role assignment endpoints instead of the deprecated direct team user association endpoints.