### PR TITLE
Add workflow job template permissions to config

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -58,6 +58,9 @@ categories:
     - controller.metrics_list
     - controller.projects_list
     - controller.job_templates_list
+    - controller.workflow_job_templates_list
+    - controller.job_templates_read
+    - controller.workflow_job_templates_read
 
   inventory_management:
     - controller.inventories_list


### PR DESCRIPTION
Added the following tools to job_management:

Listing workflow job templates
Fetching specific job template
Fetching specific workflow job template