### PR TITLE
Add new settings permissions to platform_configuration

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -142,8 +142,10 @@ categories:
     - controller.credential_types_delete
 
   platform_configuration:
+    - controller.settings_list
     - controller.settings_read
     - controller.settings_partial_update
+    - gateway.settings_list
     - gateway.settings_getter
     - gateway.settings_update
     - controller.config_list


### PR DESCRIPTION
Agents can't discover slugs needed for controller.settings_read and gateway.settings_getter without being able to list out all of the settings categories