### PR TITLE
PoC: periodic event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -371,6 +371,7 @@ const generateTools = async (): Promise<AAPMcpToolDefinition[]> => {
 
 let allTools: AAPMcpToolDefinition[] = [];
 
+const processUUID = randomUUID();
 // Initialize logger only if recording is enabled
 const toolLogger = recordApiQueries ? new ToolLogger() : null;
 
@@ -832,6 +833,25 @@ const mcpDeleteHandler = async (
     }
   }
 };
+
+async function sendStatusEvent(): null {
+  console.log("---");
+  console.log(`Server process UUID ${processUUID}`);
+  console.log(`Active session ${Object.keys(sessionData).length}`);
+  console.log(`Uptime ${Math.floor(process.uptime())}`);
+  console.log(`Tools ${Object.keys(allTools).length}`);
+  try {
+    await fetch(`${CONFIG.BASE_URL}/`, {
+      headers: {
+        Accept: "application/json",
+      },
+      timeout: 1000,
+    });
+    console.log(`AAP is reachable OK`);
+  } catch (_error) {
+    console.log(`AAP is reachable KO`);
+  }
+}
 
 // Web UI routes (only enabled if enable_ui is true)
 if (enableUI) {
@@ -1546,6 +1566,10 @@ async function main(): Promise<void> {
   console.log("═══════════════════════════════════════════════════════════");
 
   const PORT = process.env.MCP_PORT || 3000;
+
+  const _intervalId: NodeJS.Timeout = setInterval(() => {
+    sendStatusEvent();
+  }, 2000);
 
   app.listen(PORT, () => {
     console.log(`Server ready on port ${PORT}`);


### PR DESCRIPTION
Output example:

```
Server process UUID 601d3dca-9892-42fc-be4f-565c1c282dd3
Active session 0
Uptime 237
Tools 489
AAP is reachable OK
```


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Periodically logs server status (process UUID, sessions, uptime, tools) and probes AAP reachability every 2s.
> 
> - **Server status reporting (`src/index.ts`)**:
>   - Add `processUUID` and new `sendStatusEvent` to log process UUID, active sessions, uptime, and tool count.
>   - Perform a quick reachability probe to `CONFIG.BASE_URL` (`/`) with a 1s timeout; log OK/KO.
>   - Start a `setInterval` (2s) to invoke `sendStatusEvent` after startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44df539d3c99194071e10d031bafd3e5a5ad8b56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->