### PR TITLE
tool to simulate a horde of MCP clients

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,7 @@ export default [
     ],
   },
   {
-    files: ["src/**/*.ts", "src/**/*.js"],
+    files: ["src/**/*.ts", "src/**/*.js", "scripts/**/*.ts", "scripts/**/*.js"],
     languageOptions: {
       parser: tsparser,
       parserOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,12 +25,14 @@
         "aap-mcp-server": "dist/index.js"
       },
       "devDependencies": {
+        "@endorhq/cli": "^0.2.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
+        "concurrently": "^9.2.1",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.1.8",
         "tsx": "^4.20.6",
@@ -241,6 +243,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@endorhq/cli": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@endorhq/cli/-/cli-0.2.0.tgz",
+      "integrity": "sha512-xFkN0c2ZgTClx6WPcUu1oNwoe5R2Q+f7AIEPKa7+XWAfVhcz8x+q0pqEi3R1+MTxTv/mkPxyls1gfZiicVh7cw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "endor": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2470,6 +2485,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -4726,6 +4782,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4827,6 +4893,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/should": {
@@ -5315,6 +5394,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:coverage:watch": "vitest --coverage",
+    "simulate:mock-aap-server": "tsx ./scripts/mock-aap-server.ts",
+    "simulate:mcp-aap-server": "BASE_URL=http://localhost:8080 ENABLE_METRICS=true SESSION_TIMEOUT=30 tsx ./src/index.ts",
+    "simulate:horde-of-clients": "tsx ./scripts/simulate-clients.ts",
+    "simulate": "concurrently  npm:simulate:mock-aap-server npm:simulate:mcp-aap-server npm:simulate:horde-of-clients",
     "lint": "eslint src --ext .ts,.js",
     "lint:fix": "eslint src --ext .ts,.js --fix"
   },
@@ -37,12 +41,14 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
+    "@endorhq/cli": "^0.2.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
+    "concurrently": "^9.2.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "tsx": "^4.20.6",

--- a/scripts/simulate-clients.ts
+++ b/scripts/simulate-clients.ts
@@ -1,0 +1,751 @@
+#!/usr/bin/env node
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { readFileSync } from "fs";
+import { load as yamlLoad } from "js-yaml";
+
+// Configuration
+const BASE_URL = "http://localhost:3000";
+const CONFIG_FILE = "aap-mcp.yaml";
+
+// Command line arguments parsing
+const args = process.argv.slice(2);
+const getArgValue = (argName, defaultValue) => {
+  const index = args.findIndex((arg) => arg === argName);
+  if (index !== -1 && index + 1 < args.length) {
+    return args[index + 1];
+  }
+  return defaultValue;
+};
+
+// Show help if requested
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`
+Usage: node simulate-clients.js [options]
+
+Options:
+  --num-clients <number>          Number of clients to simulate (default: 100)
+  --request-interval <ms>         Interval between requests in milliseconds (default: 3000)
+  --duration <seconds>            Duration to run simulation in seconds (default: 600)
+  --token <string>                Bearer token for authentication
+  --help, -h                      Show this help message
+
+Examples:
+  node simulate-clients.js --num-clients 50
+  node simulate-clients.js --request-interval 5000
+  node simulate-clients.js --duration 300 --num-clients 20
+`);
+  process.exit(0);
+}
+
+const NUM_CLIENTS = parseInt(getArgValue("--num-clients", "100"), 10);
+const DURATION_SECONDS = parseInt(getArgValue("--duration", "600"), 10);
+const BEARER_TOKEN = getArgValue("--token", "random-string");
+
+// Metrics configuration
+const METRICS_INTERVAL = 10000; // Fetch metrics every 30 seconds
+const METRICS_URL = `${BASE_URL}/metrics`;
+
+// Load toolsets from YAML config
+let serverUrls = [];
+let toolsets = [];
+const errorsFound: string[] = [];
+
+// Give a bit of time to the mcp-server to start
+await delay(4000);
+
+try {
+  const configContent = readFileSync(CONFIG_FILE, "utf8");
+  const config = yamlLoad(configContent);
+
+  if (config.toolsets) {
+    toolsets = Object.keys(config.toolsets);
+    serverUrls = toolsets.map((toolset) => ({
+      toolset: toolset,
+      url: `${BASE_URL}/mcp/${toolset}`,
+    }));
+    console.log(
+      `📂 Loaded ${toolsets.length} toolsets: ${toolsets.join(", ")}`,
+    );
+  } else if (config.categories) {
+    // Fallback to old categories format
+    toolsets = Object.keys(config.categories);
+    serverUrls = toolsets.map((toolset) => ({
+      toolset: toolset,
+      url: `${BASE_URL}/mcp/${toolset}`,
+    }));
+    console.log(
+      `📂 Loaded ${toolsets.length} toolsets (from categories): ${toolsets.join(", ")}`,
+    );
+  } else {
+    throw new Error("No toolsets found in config file");
+  }
+} catch (error) {
+  console.error("❌ Failed to load toolsets from config file:", error.message);
+  console.log("📋 Using fallback toolsets");
+  toolsets = ["all", "job_management", "inventory_management"];
+  serverUrls = toolsets.map((toolset) => ({
+    toolset: toolset,
+    url: `${BASE_URL}/mcp/${toolset}`,
+  }));
+}
+
+// Client state tracking
+const clients = new Map();
+let nextClientId = 1; // Counter for assigning unique client IDs
+
+const randomKillStats = {
+  totalTerminated: 0,
+  terminatedThisMinute: 0,
+  lastRandomKillTime: null,
+};
+
+const connectionCreationStats = {
+  totalCreated: 0,
+  createdThisInterval: 0,
+  lastCreationTime: null,
+};
+
+class MCPClientSimulator {
+  constructor(id, serverUrl, toolset) {
+    this.id = id;
+    this.serverUrl = serverUrl;
+    this.toolset = toolset;
+    this.userAgent = `MCP-Test-Client/${id}`;
+    this.isActive = false;
+    this.client = null;
+    this.transport = null;
+    this.interval = null;
+    this.wasTerminatedAbruptly = false;
+    this.randomKillCount = 0;
+    this.tools = [];
+  }
+
+  async initialize() {
+    try {
+      console.log(
+        `[Client ${this.id}] Initializing with toolset: ${this.toolset}`,
+      );
+
+      // Create HTTP transport with authentication and user agent
+      // Note: StreamableHTTPClientTransport has limited header support
+      // Authorization headers may not be transmitted properly
+      this.transport = new StreamableHTTPClientTransport(this.serverUrl, {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${BEARER_TOKEN}`,
+            "User-Agent": this.userAgent,
+            "mcp-protocol-version": "2025-06-18",
+            "accept-language": "*",
+          },
+        },
+      });
+
+      // Create MCP client
+      this.client = new Client(
+        {
+          name: `test-client-${this.id}`,
+          version: "1.0.0",
+        },
+        {
+          capabilities: {
+            tools: {},
+          },
+          protocolVersion: "2025-06-18",
+        },
+      );
+
+      // Connect to server
+      await this.client.connect(this.transport);
+
+      console.log(`[Client ${this.id}] Connected successfully`);
+      this.isActive = true;
+      return true;
+    } catch (error) {
+      console.error(
+        `[Client ${this.id}] Initialization failed:`,
+        error.message,
+      );
+      await this.cleanup();
+      return false;
+    }
+  }
+
+  async listTools() {
+    if (!this.isActive || !this.client) {
+      console.error(`[Client ${this.id}] Not connected, skipping tools/list`);
+      return false;
+    }
+
+    try {
+      // Use SDK's built-in listTools method
+      const response = await this.client.listTools();
+
+      const toolCount = response.tools?.length || 0;
+      if (toolCount > 0) {
+        this.tools = response.tools;
+      }
+      console.log(
+        `[Client ${this.id}] Listed ${toolCount} tools (toolset: ${this.toolset})`,
+      );
+      return true;
+    } catch (error) {
+      console.error(`[Client ${this.id}] tools/list failed:`, error.message);
+
+      // Handle connection errors by marking client as inactive
+      if (
+        error.message.includes("connection") ||
+        error.message.includes("session") ||
+        error.message.includes("transport")
+      ) {
+        console.log(`[Client ${this.id}] Connection lost, marking inactive`);
+        this.isActive = false;
+        await this.cleanup();
+      }
+      return false;
+    }
+  }
+
+  async callTool() {
+    if (!this.isActive || !this.client) {
+      console.error(`[Client ${this.id}] Not connected, skipping callTool`);
+      return false;
+    }
+    if (this.tools.length === 0) {
+      console.error(
+        `[Client ${this.id}] Not tools available, skipping callTool`,
+      );
+      return false;
+    }
+    const toolsWithNoRequiredParameters = this.tools.filter(
+      (tool) =>
+        !tool.inputSchema.required || tool.inputSchema.required.length === 0,
+    );
+
+    if (toolsWithNoRequiredParameters.length === 0) {
+      console.error(
+        `[Client ${this.id}] Empty list of tools with no required parameters, skipping callTool`,
+      );
+      return false;
+    }
+
+    const tool = toolsWithNoRequiredParameters[0];
+    const params = {
+      name: tool.name,
+    };
+    await this.client
+      .callTool(params)
+      .catch((e) =>
+        console.log(
+          `Unexpected tool answer when calling tool ${tool.name}: ${e}`,
+        ),
+      );
+  }
+
+  async cleanup() {
+    try {
+      if (this.client) {
+        await this.client.close();
+        this.client = null;
+      }
+      if (this.transport) {
+        await this.transport.close();
+        this.transport = null;
+      }
+    } catch (error) {
+      console.error(`[Client ${this.id}] Cleanup error:`, error.message);
+    }
+    this.isActive = false;
+  }
+
+  async disconnect() {
+    if (!this.isActive) {
+      return;
+    }
+
+    try {
+      await this.cleanup();
+      console.log(`[Client ${this.id}] Disconnected`);
+    } catch (error) {
+      console.error(`[Client ${this.id}] Disconnect failed:`, error.message);
+    }
+  }
+
+  // Abrupt disconnection without proper cleanup - simulates network failure or client crash
+  abruptDisconnect() {
+    console.log(
+      `🔥 [Client ${this.id}] ABRUPT DISCONNECTION - Simulating client crash/network failure`,
+    );
+
+    // Mark as abruptly terminated
+    this.wasTerminatedAbruptly = true;
+    this.randomKillCount++;
+    this.isActive = false;
+
+    // Clear interval to stop periodic requests
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+
+    // Do NOT call cleanup() - this simulates an abrupt disconnection
+    // The server should detect the broken connection via session timeout
+    this.client = null;
+    this.transport = null;
+
+    // Update global stats
+    randomKillStats.totalTerminated++;
+    randomKillStats.terminatedThisMinute++;
+
+    console.log(
+      `💀 [Client ${this.id}] Session abandoned (randomKill #${this.randomKillCount}). Server should clean up via timeout.`,
+    );
+  }
+
+  startPeriodicRequests() {
+    const interval = setInterval(
+      async () => {
+        if (!this.isActive) {
+          if (this.wasTerminatedAbruptly) {
+            console.log(
+              `🔄 [Client ${this.id}] Attempting to reconnect after abrupt randomKill...`,
+            );
+            // Reset randomKill flag for reconnection
+            this.wasTerminatedAbruptly = false;
+          } else {
+            console.log(`[Client ${this.id}] Attempting to reconnect...`);
+          }
+
+          const success = await this.initialize();
+          if (!success) {
+            return;
+          }
+        }
+
+        if (this.tools.length === 0) {
+          await this.listTools();
+        } else {
+          await this.callTool();
+        }
+      },
+      Math.floor(Math.random() * 10000),
+    );
+
+    // Store interval for cleanup
+    this.interval = interval;
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.disconnect();
+  }
+}
+
+// Utility functions
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Parse Prometheus format metrics
+function parsePrometheusMetrics(text) {
+  const metrics = [];
+  const lines = text.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments that are not metadata
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    // Parse metric lines
+    const lineFields = trimmed.split(" ");
+    if (lineFields.length > 1) {
+      metrics.push({
+        name: lineFields[0],
+        value: lineFields[1],
+      });
+    }
+  }
+
+  return metrics;
+}
+
+// Fetch and parse server metrics
+async function fetchServerMetrics() {
+  try {
+    const response = await fetch(METRICS_URL, {
+      method: "GET",
+      headers: {
+        Accept: "text/plain",
+        "User-Agent": "MCP-Simulation-Client/1.0",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const text = await response.text();
+    const rawMetrics = parsePrometheusMetrics(text);
+
+    // Extract relevant metrics for our dashboard
+    const serverMetrics = {
+      heapSizeUsedBytes: 0,
+      mcpSessionsActiveTotal: 0,
+      mcpSessionsTimeoutTotal: 0,
+      timestamp: new Date(),
+    };
+
+    // Map Prometheus metrics to our structure
+    for (const metric of rawMetrics) {
+      switch (metric.name) {
+        case "nodejs_heap_size_used_bytes":
+          serverMetrics.heapSizeUsedBytes = metric.value;
+          break;
+        case "mcp_sessions_active_total":
+          serverMetrics.mcpSessionsActiveTotal = metric.value;
+          break;
+        case "mcp_sessions_timeout_total":
+          serverMetrics.mcpSessionsTimeoutTotal = metric.value;
+          break;
+      }
+    }
+
+    return { success: true, metrics: serverMetrics, rawMetrics };
+  } catch (error) {
+    console.error(`❌ Failed to fetch server metrics: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+}
+
+// Format metrics for display
+function formatMetrics(metrics) {
+  return [
+    `📊 Server Metrics (${metrics.timestamp.toLocaleTimeString()}):`,
+    `   🔗 Memory: ${(metrics.heapSizeUsedBytes / 1000000).toFixed(1)}MB`,
+    `   🎫 MCP Sessions: ${metrics.mcpSessionsActiveTotal} active, ${metrics.mcpSessionsTimeoutTotal} timeouts`,
+  ].join("\n");
+}
+
+function getStats() {
+  const activeClients = Array.from(clients.values()).filter(
+    (c) => c.isActive,
+  ).length;
+  const totalClients = clients.size;
+  const terminatedClients = Array.from(clients.values()).filter(
+    (c) => c.wasTerminatedAbruptly && !c.isActive,
+  ).length;
+
+  return {
+    active: activeClients,
+    total: totalClients,
+    terminated: terminatedClients,
+    totalRandomKills: randomKillStats.totalTerminated,
+    totalCreated: connectionCreationStats.totalCreated,
+  };
+}
+
+// Periodically terminate a percentage of active clients abruptly
+function startConnectionRandomKill() {
+  setInterval(
+    () => {
+      const activeClients = Array.from(clients.values()).filter(
+        (c) => c.isActive,
+      );
+
+      if (activeClients.length === 0) {
+        return;
+      }
+
+      // Calculate how many clients to terminate (25% of active clients)
+
+      // Randomly select clients to terminate
+      const shuffled = activeClients.sort(() => 0.5 - Math.random());
+      const clientsToTerminate = shuffled.slice(
+        0,
+        Math.floor(Math.random() * 10),
+      );
+
+      console.log(
+        `\n🎯 RANDOMKILL EVENT: Abruptly disconnecting ${clientsToTerminate.length}/${activeClients.length} active clients`,
+      );
+
+      // Reset this minute's counter
+      randomKillStats.terminatedThisMinute = 0;
+
+      // Terminate selected clients
+      clientsToTerminate.forEach((client) => {
+        client.abruptDisconnect();
+      });
+
+      console.log(
+        `💥 ${clientsToTerminate.length} clients terminated abruptly. Server should detect and clean up sessions via timeout.\n`,
+      );
+    },
+    Math.floor(Math.random() * 10000),
+  );
+}
+
+// Periodically create new connections to test dynamic scaling
+function startConnectionCreation() {
+  setInterval(
+    () => {
+      if (clients.size === 0) {
+        return;
+      }
+      // Create 1-3 new connections each cycle (every 120 seconds by default)
+      const numToCreate = Math.floor(Math.random() * 3) + 1;
+
+      console.log(
+        `\n🌟 CONNECTION CREATION EVENT: Creating ${numToCreate} new connections`,
+      );
+
+      // Reset this interval's counter
+      connectionCreationStats.createdThisInterval = 0;
+
+      for (let i = 0; i < numToCreate; i++) {
+        // Select random server/toolset
+        const serverUrlIndex = Math.floor(Math.random() * serverUrls.length);
+        const selectedServer = serverUrls[serverUrlIndex];
+
+        // Create new client with unique ID
+        const clientId = nextClientId++;
+        const client = new MCPClientSimulator(
+          clientId,
+          selectedServer.url,
+          selectedServer.toolset,
+        );
+
+        clients.set(clientId, client);
+
+        // Update creation stats
+        connectionCreationStats.totalCreated++;
+        connectionCreationStats.createdThisInterval++;
+        connectionCreationStats.lastCreationTime = new Date();
+
+        console.log(
+          `🆕 [Client ${clientId}] Creating new connection for toolset: ${selectedServer.toolset}`,
+        );
+
+        // Initialize client asynchronously
+        client
+          .initialize()
+          .then((success) => {
+            if (success) {
+              client.startPeriodicRequests();
+              console.log(
+                `✅ [Client ${clientId}] Successfully connected and started`,
+              );
+            } else {
+              console.log(`❌ [Client ${clientId}] Failed to initialize`);
+            }
+          })
+          .catch((error) => {
+            console.error(
+              `💥 [Client ${clientId}] Initialization error:`,
+              error.message,
+            );
+          });
+      }
+
+      console.log(
+        `🌟 ${numToCreate} new connections created. Total created: ${connectionCreationStats.totalCreated}\n`,
+      );
+    },
+    Math.floor(Math.random() * 10000),
+  );
+}
+
+// Main simulation logic
+async function startSimulation() {
+  console.log(`🚀 Starting MCP client simulation with ${NUM_CLIENTS} clients`);
+  console.log(`📡 Base URL: ${BASE_URL}`);
+  console.log(`🔗 Server URLs: ${serverUrls.map((s) => s.url).join(", ")}`);
+  console.log(
+    `⏰ Duration: ${DURATION_SECONDS}s (${Math.floor(DURATION_SECONDS / 60)}m ${DURATION_SECONDS % 60}s)`,
+  );
+  console.log(`🔑 Bearer token: ${BEARER_TOKEN.substring(0, 10)}...`);
+  console.log(`🔧 Using MCP SDK Client for communication`);
+  console.log("─".repeat(60));
+
+  // Create and initialize clients with staggered startup
+  for (let i = 1; i <= NUM_CLIENTS; i++) {
+    // Distribute clients across different server URLs
+    const serverUrlIndex = (i - 1) % serverUrls.length;
+    const selectedServer = serverUrls[serverUrlIndex];
+
+    const client = new MCPClientSimulator(
+      i,
+      selectedServer.url,
+      selectedServer.toolset,
+    );
+    clients.set(i, client);
+
+    // Update next client ID counter
+    nextClientId = Math.max(nextClientId, i + 1);
+
+    // Initialize client
+    const success = await client.initialize();
+
+    if (success) {
+      // Start periodic requests
+      client.startPeriodicRequests();
+    }
+
+    // Stagger client startup to avoid overwhelming the server
+    if (i < NUM_CLIENTS) {
+      await delay(100); // 100ms delay between client startups
+    }
+  }
+
+  // Start metrics fetching if enabled
+  let latestMetrics = null;
+  let metricsInterval = null;
+
+  metricsInterval = setInterval(async () => {
+    const result = await fetchServerMetrics();
+    if (result.success) {
+      latestMetrics = result.metrics;
+      console.log("\n" + formatMetrics(latestMetrics));
+    }
+  }, METRICS_INTERVAL);
+
+  // Log periodic stats
+  const statsInterval = setInterval(() => {
+    const stats = getStats();
+
+    // Count clients per toolset
+    const toolsetStats = new Map();
+    Array.from(clients.values()).forEach((client) => {
+      if (client.isActive) {
+        toolsetStats.set(
+          client.toolset,
+          (toolsetStats.get(client.toolset) || 0) + 1,
+        );
+      }
+    });
+
+    const toolsetStatsStr = Array.from(toolsetStats.entries())
+      .map(([toolset, count]) => `${toolset}: ${count}`)
+      .join(", ");
+
+    // Enhanced stats with server metrics correlation
+    let metricsCorrelation = "";
+    if (latestMetrics) {
+      const serverSessions = latestMetrics.activeSessions;
+      const clientSessions = stats.active;
+      const sessionDiff = Math.abs(serverSessions - clientSessions);
+
+      if (sessionDiff > 0) {
+        metricsCorrelation = ` | Server sees ${serverSessions} sessions (±${sessionDiff})`;
+      } else {
+        metricsCorrelation = ` | Server sessions: ✅ ${serverSessions}`;
+      }
+    }
+
+    console.log(
+      `📊 Active: ${stats.active}/${stats.total} | Terminated: ${stats.terminated} (kills: ${stats.totalRandomKills}) | Created: ${stats.totalCreated} | Toolsets: ${toolsetStatsStr}${metricsCorrelation} | ${new Date().toLocaleTimeString()}`,
+    );
+  }, 10000); // Every 10 seconds
+
+  // Set up duration timeout for automatic shutdown
+  const durationTimeout = setTimeout(async () => {
+    console.log(
+      `\n⏰ Duration limit (${DURATION_SECONDS}s) reached. Shutting down simulation...`,
+    );
+    clearInterval(statsInterval);
+    if (metricsInterval) {
+      clearInterval(metricsInterval);
+    }
+
+    // Stop all clients
+    const disconnectPromises = Array.from(clients.values()).map((client) => {
+      client.abruptDisconnect();
+    });
+
+    clients.clear();
+    await Promise.allSettled(disconnectPromises);
+
+    console.log(
+      "\n📊 Test is done, waiting 35s to be sure all the sessions are properly closed before collecting the final metrics.",
+    );
+    await delay(35000);
+
+    // Final metrics fetch
+    console.log("\n📊 Final server metrics:");
+    const finalMetrics = await fetchServerMetrics();
+    if (finalMetrics?.metrics?.mcpSessionsActiveTotal !== 0) {
+      errorsFound.push(
+        "Some remaining sessions were found after the end of the test",
+      );
+    }
+    if (finalMetrics.success) {
+      console.log(formatMetrics(finalMetrics.metrics));
+    }
+
+    console.log("🏁 Simulation completed successfully");
+    process.exit(0);
+  }, DURATION_SECONDS * 1000);
+
+  // Handle graceful shutdown
+  process.on("SIGINT", async () => {
+    console.log("\n🛑 Shutting down simulation...");
+    clearInterval(statsInterval);
+    if (metricsInterval) {
+      clearInterval(metricsInterval);
+    }
+    clearTimeout(durationTimeout);
+
+    // Stop all clients
+    const disconnectPromises = Array.from(clients.values()).map((client) => {
+      client.stop();
+    });
+
+    await Promise.allSettled(disconnectPromises);
+
+    console.log("✅ All clients disconnected");
+    if (errorsFound.length > 0) {
+      console.log("Error founds during the run!", errorsFound);
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+
+  // Start the abrupt connection randomKill process
+  console.log(`🎯 Starting abrupt connection randomKill...`);
+  startConnectionRandomKill();
+
+  // Start the connection creation process
+  console.log(`🌟 Starting connection creation system...`);
+  startConnectionCreation();
+
+  console.log("✅ Simulation started! Press Ctrl+C to stop manually");
+  console.log("📊 Stats will be logged every 10 seconds");
+  console.log("💀 Abrupt randomKills will begin after 1 minute");
+  console.log("🌟 New connections will be created every 2 minutes");
+  console.log(
+    `⏰ Simulation will auto-stop after ${DURATION_SECONDS}s (${Math.floor(DURATION_SECONDS / 60)}m ${DURATION_SECONDS % 60}s)`,
+  );
+}
+
+// Error handling
+process.on("unhandledRejection", (error) => {
+  console.error("🚨 Unhandled rejection:", error);
+});
+
+process.on("uncaughtException", (error) => {
+  console.error("🚨 Uncaught exception:", error);
+  process.exit(1);
+});
+
+// Start the simulation
+startSimulation().catch((error) => {
+  console.error("🚨 Failed to start simulation:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Node.js tool to simulate many MCP clients that initialize sessions, periodically list tools via SSE, and report stats with graceful shutdown.
> 
> - **Tools**:
>   - **New script**: `tools/simulate-clients.js`
>     - Simulates up to `NUM_CLIENTS` concurrent MCP clients across categories loaded from `aap-mcp.yaml` (fallback categories supported).
>     - Establishes sessions (`initialize`), performs periodic `tools/list` requests, and handles SSE parsing.
>     - Tracks client state, reconnection, and disconnection; logs periodic stats by category.
>     - Supports bearer auth, configurable intervals, and graceful shutdown on SIGINT with error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 382d5ce6e6febb845d0852b8d9612d4689efd573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->