### PR TITLE
use one single session system

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,7 @@ cp aap-mcp.sample.yaml aap-mcp.yaml
 # Edit aap-mcp.yaml with your AAP instance details
 ```
 
-2. **Set your authentication token**:
-
-```bash
-export BEARER_TOKEN_OAUTH2_AUTHENTICATION=your_aap_token_here
-```
-
-3. **Start the service**:
+2. **Start the service**:
 
 ```bash
 # Development mode


### PR DESCRIPTION
- converge toward only using `sessionData` and remove the `transports`
  global variable.
- remove both `is_superuser` and `is_platform_auditor` from the session
  since we don't use them.
- store `userAgent` in the session, instead has a `transport` attribute.
- store the `category` in the session.
- remove the FALLBACK_BEARER_TOKEN system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates session handling into `sessionData` (token, userAgent, category, transport), simplifies token validation (no permission extraction), updates MCP handlers to use session-stored data, and removes README token export step.
> 
> - **Server / Session Management**:
>   - Replace global `transports` map with a single `sessionData` store holding `token`, `userAgent`, `category`, and `transport`.
>   - Remove `is_superuser` and `is_platform_auditor` from sessions and delete related permission-fetch logic.
>   - Drop fallback env token usage and `getBearerTokenForSession`; tools now use the session’s token.
>   - Update MCP `POST/GET/DELETE` handlers and shutdown/cleanup to reference `sessionData` exclusively.
> - **Auth & Categories**:
>   - Change token check to validation-only (`/api/gateway/v1/me/`) without parsing user info.
>   - Persist `category` per session; `ListTools` filters by session category.
>   - Improve `getUserCategory`: default to `all`, or return all tools if `all` is missing.
> - **Docs**:
>   - Remove step instructing users to export `BEARER_TOKEN_OAUTH2_AUTHENTICATION` before starting the service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8f531c09d9cb5c7e4fa94f72b7929c051bae6e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->