### PR TITLE
Improve launch/relaunch job UX

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -47,6 +47,7 @@ services:
 categories:
   # Phase 1
   job_management:
+    - controller.job_templates_launch_retrieve
     - controller.job_templates_launch_create
     - controller.workflow_job_templates_launch_create
     - controller.jobs_retrieve

--- a/data/controller-schema.json
+++ b/data/controller-schema.json
@@ -10549,7 +10549,7 @@
                         "description": ""
                     }
                 },
-                "x-ai-description": "Launch a job from a job template to execute an Ansible playbook"
+                "x-ai-description": "Launch a job from a job template to execute an Ansible playbook.  Perform a GET request on /job_templates/{id}/launch/ (operationId: job_templates_launch_retrieve) before launching to get the parameters the API expects when launching a job template."
             }
         },
         "/api/v2/job_templates/{id}/notification_templates_error/": {


### PR DESCRIPTION
Something I noticed when testing out relaunching a job... In the UI, they make a GET request to the /relaunch endpoint first in order to get the full picture of what the API expects in the requestBody.  I've updated our x-ai-description to suggest that.  I've also included that tool (retrieving the relaunch config)

I also noticed that the "type" for credential_passwords is incorrectly labeled as a string when it should be an object like this:

```
{
  "credential_passwords": {
    "machine": "foobar"
  }
}
```

So I tweaked that.  I'll need to open up a ticket for this to be addressed upstream.

Note that I also added a similar enhancement for launching a job.  I updated the x-ai-description and I included the tool that will allow agents to GET the launch config before the POST.