### PR TITLE
rename category to toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ services:
 - **local_path**: Path to local OpenAPI file (optional, if set, loads from file instead of URL)
 - **enabled**: Enable/disable the service (optional, defaults to true)
 
-#### Tool Categories
+#### Toolsets
 
-Define custom tool categories that group related functionality:
+Define custom toolsets that group related functionality:
 
 ```yaml
-categories:
+toolsets:
   job_management:
     - controller.job_templates_launch_create
     - controller.workflow_job_templates_launch_create
@@ -135,9 +135,9 @@ Configuration values are resolved in the following order (highest to lowest prio
 2. **Configuration File** (`aap-mcp.yaml`)
 3. **Default Values** (built-in defaults)
 
-### User Categories
+### User Toolsets
 
-The service supports role-based access control through user categories.
+The service supports role-based access control through user toolsets.
 
 ## Usage
 
@@ -166,7 +166,7 @@ When `enable_ui: true` is set in the configuration, the service provides a web i
 
 - **Dashboard**: `http://localhost:3000/` - Service overview and statistics
 - **Tools List**: `http://localhost:3000/tools` - Browse all available tools
-- **Categories**: `http://localhost:3000/category` - View tools by category
+- **Toolsets**: `http://localhost:3000/toolset` - View tools by toolset
 - **Services**: `http://localhost:3000/services` - Service-specific tool listings
 - **Logs**: `http://localhost:3000/logs` - API query logs (when logging is enabled)
 - **Health**: `http://localhost:3000/api/v1/health` - Service health check
@@ -176,7 +176,7 @@ When `enable_ui: true` is set in the configuration, the service provides a web i
 The service provides several MCP endpoints:
 
 - **Standard MCP**: `/mcp` (POST, GET, DELETE)
-- **Category-specific**: `/mcp/{category}` where category matches your configured categories
+- **Toolset-specific**: `/mcp/{toolset}` where toolset matches your configured toolsets
 
 ### Authentication
 
@@ -222,9 +222,9 @@ npm run dev
 claude mcp add aap-mcp -t http http://localhost:3000/mcp
 ```
 
-#### Option 3: Using Custom Categories
+#### Option 3: Using Custom Toolsets
 
-To use specific tool categories defined in your configuration:
+To use specific toolsets defined in your configuration:
 
 ```bash
 # Use job management tools only
@@ -246,7 +246,7 @@ The service generates tools from AAP OpenAPI specifications for:
 - **Gateway**: User and team management, organizations, role definitions
 - **Galaxy**: Collection management and versions
 
-Tool availability depends on your configured categories and user permissions. When the web UI is enabled, you can browse available tools at `http://localhost:3000/tools`.
+Tool availability depends on your configured toolsets and user permissions. When the web UI is enabled, you can browse available tools at `http://localhost:3000/tools`.
 
 ## Prometheus Metrics
 
@@ -286,7 +286,7 @@ http://localhost:3000/metrics
 - **Service Selection**: Enable/disable specific AAP services
 - **Local File Support**: Load OpenAPI specs from local files or remote URLs
 - **Web UI Dashboard**: Optional web interface for browsing tools and logs
-- **Role-based Access Control**: Custom categories and permission-based tool filtering
+- **Role-based Access Control**: Custom toolsets and permission-based tool filtering
 - **Session Management**: Token validation and user permission detection
 - **API Query Logging**: Optional logging of all tool usage
 - **Prometheus Metrics**: Comprehensive metrics for monitoring and observability
@@ -303,7 +303,7 @@ The configuration system follows a hierarchical approach:
 
 2. **YAML Configuration File** (`aap-mcp.yaml`)
    - Service definitions with custom URLs and local file paths
-   - Custom tool categories for role-based access
+   - Custom toolsets for role-based access
    - Feature toggles (UI, logging, certificate validation)
 
 3. **Built-in Defaults** (lowest priority)
@@ -371,7 +371,7 @@ The Kubernetes deployment includes:
 2. **No tools available**:
    - Check that your token provides the expected user permissions
    - Verify services are enabled in your configuration
-   - Check the category configuration matches your intended tool access
+   - Check the toolset configuration matches your intended tool access
 
 3. **Connection refused**:
    - Ensure AAP is running and accessible at the configured base URL
@@ -407,7 +407,7 @@ The service provides detailed console logging for:
 - OpenAPI specification loading (local files vs URLs)
 - Service enabling/disabling
 - Session initialization and cleanup
-- Tool filtering by category
+- Tool filtering by toolset
 - API request execution and responses
 
 Enable additional logging:

--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -44,7 +44,7 @@ services:
     local_path: data/eda-openapi.json
     # enabled: true
 
-categories:
+toolsets:
   # Phase 1
   job_management:
     - controller.job_templates_launch_retrieve

--- a/src/header.ts
+++ b/src/header.ts
@@ -5,7 +5,7 @@ export const renderHeader = (): string => {
             <a href="/tools" class="nav-link">Tools</a>
             <a href="/services" class="nav-link">Services</a>
             <a href="/endpoints" class="nav-link">Endpoints</a>
-            <a href="/category" class="nav-link">Categories</a>
+            <a href="/toolset" class="nav-link">Toolsets</a>
             <a href="/logs" class="nav-link">Logs</a>
         </div>`;
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,7 +13,7 @@ export interface LogEntry {
 export interface Tool {
   name: string;
   service?: string;
-  category?: string;
+  toolset?: string;
   [key: string]: any;
 }
 
@@ -61,14 +61,15 @@ export class ToolLogger {
     // Record metrics
     const duration = startTime ? (Date.now() - startTime) / 1000 : 0;
     const status = returnCode >= 200 && returnCode < 400 ? "success" : "error";
+    // TODO: service and toolset should always be defined
     const service = tool.service || "unknown";
-    const category = tool.category || "uncategorized";
+    const toolset = tool.toolset || "unknown";
 
     // Prometheus metrics
     metricsService.recordToolExecution(
       tool.name,
       service,
-      category,
+      toolset,
       status,
       duration,
     );
@@ -77,7 +78,7 @@ export class ToolLogger {
     if (status === "error") {
       const errorType =
         returnCode >= 400 && returnCode < 500 ? "client_error" : "server_error";
-      metricsService.recordToolError(tool.name, service, category, errorType);
+      metricsService.recordToolError(tool.name, service, toolset, errorType);
     }
   }
 }

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -18,7 +18,7 @@ describe("MetricsService", () => {
     metricsService.recordToolExecution(
       "test_tool",
       "test_service",
-      "test_category",
+      "test_toolset",
       "success",
       0.1, // 100ms
     );
@@ -40,7 +40,7 @@ describe("MetricsService", () => {
     metricsService.recordToolError(
       "test_tool",
       "test_service",
-      "test_category",
+      "test_toolset",
       "timeout",
     );
 
@@ -98,14 +98,14 @@ describe("MetricsService", () => {
     metricsService.recordToolExecution(
       "tool1",
       "service1",
-      "category1",
+      "toolset1",
       "success",
       0.1,
     );
     metricsService.recordToolExecution(
       "tool2",
       "service2",
-      "category2",
+      "toolset2",
       "error",
       0.2,
     );
@@ -119,7 +119,7 @@ describe("MetricsService", () => {
     metricsService.recordToolExecution(
       "test_tool",
       "test_service",
-      "test_category",
+      "test_toolset",
       "success",
       0,
     );

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -41,14 +41,14 @@ export class MetricsService {
     this.mcpToolExecutionsTotal = new Counter({
       name: "mcp_tool_executions_total",
       help: "Total number of MCP tool executions",
-      labelNames: ["tool_name", "service", "category", "status"],
+      labelNames: ["tool_name", "service", "toolset", "status"],
       registers: [register],
     });
 
     this.mcpToolExecutionDuration = new Histogram({
       name: "mcp_tool_execution_duration_seconds",
       help: "MCP tool execution duration in seconds",
-      labelNames: ["tool_name", "service", "category"],
+      labelNames: ["tool_name", "service", "toolset"],
       buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
       registers: [register],
     });
@@ -56,7 +56,7 @@ export class MetricsService {
     this.mcpToolErrors = new Counter({
       name: "mcp_tool_errors_total",
       help: "Total number of MCP tool execution errors",
-      labelNames: ["tool_name", "service", "category", "error_type"],
+      labelNames: ["tool_name", "service", "toolset", "error_type"],
       registers: [register],
     });
 
@@ -102,25 +102,25 @@ export class MetricsService {
   recordToolExecution(
     toolName: string,
     service: string,
-    category: string,
+    toolset: string,
     status: "success" | "error",
     duration: number,
   ): void {
     this.mcpToolExecutionsTotal
-      .labels(toolName, service, category, status)
+      .labels(toolName, service, toolset, status)
       .inc();
     this.mcpToolExecutionDuration
-      .labels(toolName, service, category)
+      .labels(toolName, service, toolset)
       .observe(duration);
   }
 
   recordToolError(
     toolName: string,
     service: string,
-    category: string,
+    toolset: string,
     errorType: string,
   ): void {
-    this.mcpToolErrors.labels(toolName, service, category, errorType).inc();
+    this.mcpToolErrors.labels(toolName, service, toolset, errorType).inc();
   }
 
   setActiveTools(service: string, count: number): void {

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -48,21 +48,15 @@ describe("SessionManager", () => {
       const sessionId = "session-123";
       const token = "token-456";
       const userAgent = "TestAgent/1.0";
-      const category = "test-category";
+      const toolset = "test-toolset";
 
-      sessionManager.store(
-        sessionId,
-        token,
-        userAgent,
-        category,
-        mockTransport,
-      );
+      sessionManager.store(sessionId, token, userAgent, toolset, mockTransport);
 
       expect(sessionManager.has(sessionId)).toBe(true);
       expect(sessionManager.get(sessionId)).toEqual({
         token,
         userAgent,
-        category,
+        toolset,
         transport: mockTransport,
       });
     });
@@ -72,7 +66,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -91,12 +85,12 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
       expect(loggedMessage).toMatch(
-        /Stored session data for session-1: userAgent=Agent\/1\.0, category=category1, active_session\(s\)=1/,
+        /Stored session data for session-1: userAgent=Agent\/1\.0, toolset=toolset1, active_session\(s\)=1/,
       );
 
       console.log = originalLog;
@@ -107,7 +101,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       expect(sessionManager.getActiveCount()).toBe(1);
@@ -116,7 +110,7 @@ describe("SessionManager", () => {
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -130,7 +124,7 @@ describe("SessionManager", () => {
         sessionId,
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       expect(sessionManager.getToken(sessionId)).toBe("token-1");
@@ -140,11 +134,11 @@ describe("SessionManager", () => {
         sessionId,
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
       expect(sessionManager.getToken(sessionId)).toBe("token-2");
-      expect(sessionManager.getCategory(sessionId)).toBe("category2");
+      expect(sessionManager.getToolset(sessionId)).toBe("toolset2");
     });
   });
 
@@ -154,7 +148,7 @@ describe("SessionManager", () => {
       const expectedData = {
         token: "token-1",
         userAgent: "Agent/1.0",
-        category: "category1",
+        toolset: "toolset1",
         transport: mockTransport,
       };
 
@@ -162,7 +156,7 @@ describe("SessionManager", () => {
         sessionId,
         expectedData.token,
         expectedData.userAgent,
-        expectedData.category,
+        expectedData.toolset,
         expectedData.transport,
       );
 
@@ -180,7 +174,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       expect(sessionManager.has("session-1")).toBe(true);
@@ -202,7 +196,7 @@ describe("SessionManager", () => {
         sessionId,
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -216,7 +210,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.delete("session-1");
@@ -232,7 +226,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -260,14 +254,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -290,14 +284,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -312,14 +306,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -344,7 +338,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       expect(sessionManager.getActiveCount()).toBe(1);
@@ -353,7 +347,7 @@ describe("SessionManager", () => {
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -372,7 +366,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-123",
         "TestAgent/1.0",
-        "test-category",
+        "test-toolset",
         mockTransport,
       );
     });
@@ -387,13 +381,13 @@ describe("SessionManager", () => {
       });
     });
 
-    describe("getCategory()", () => {
-      it("should return category for existing session", () => {
-        expect(sessionManager.getCategory("session-1")).toBe("test-category");
+    describe("getToolset()", () => {
+      it("should return toolset for existing session", () => {
+        expect(sessionManager.getToolset("session-1")).toBe("test-toolset");
       });
 
       it("should return undefined for non-existent session", () => {
-        expect(sessionManager.getCategory("non-existent")).toBeUndefined();
+        expect(sessionManager.getToolset("non-existent")).toBeUndefined();
       });
     });
 
@@ -424,14 +418,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -452,7 +446,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -482,14 +476,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         errorTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport,
       );
 
@@ -517,7 +511,7 @@ describe("SessionManager", () => {
       (sessionManager as any).sessions["session-1"] = {
         token: "token-1",
         userAgent: "Agent/1.0",
-        category: "category1",
+        toolset: "toolset1",
         transport: undefined,
       };
 
@@ -539,14 +533,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -555,7 +549,7 @@ describe("SessionManager", () => {
 
       // Verify individual access
       expect(sessionManager.getToken("session-1")).toBe("token-1");
-      expect(sessionManager.getCategory("session-2")).toBe("category2");
+      expect(sessionManager.getToolset("session-2")).toBe("toolset2");
 
       // Delete one session
       sessionManager.delete("session-1");
@@ -574,7 +568,7 @@ describe("SessionManager", () => {
         id: "session-test",
         token: "token-test",
         userAgent: "TestSuite/1.0",
-        category: "integration-test",
+        toolset: "integration-test",
       };
 
       // Store session
@@ -582,7 +576,7 @@ describe("SessionManager", () => {
         sessionData.id,
         sessionData.token,
         sessionData.userAgent,
-        sessionData.category,
+        sessionData.toolset,
         mockTransport,
       );
 
@@ -590,7 +584,7 @@ describe("SessionManager", () => {
       expect(sessionManager.get(sessionData.id)).toEqual({
         token: sessionData.token,
         userAgent: sessionData.userAgent,
-        category: sessionData.category,
+        toolset: sessionData.toolset,
         transport: mockTransport,
       });
 
@@ -598,8 +592,8 @@ describe("SessionManager", () => {
       expect(sessionManager.getUserAgent(sessionData.id)).toBe(
         sessionData.userAgent,
       );
-      expect(sessionManager.getCategory(sessionData.id)).toBe(
-        sessionData.category,
+      expect(sessionManager.getToolset(sessionData.id)).toBe(
+        sessionData.toolset,
       );
       expect(sessionManager.getTransport(sessionData.id)).toBe(mockTransport);
     });
@@ -613,7 +607,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -635,7 +629,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -662,7 +656,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -687,7 +681,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -706,14 +700,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -732,7 +726,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -761,7 +755,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -789,7 +783,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -802,8 +796,8 @@ describe("SessionManager", () => {
       // Wait another 5 seconds
       vi.advanceTimersByTime(5000);
 
-      // Access via getCategory() - should reset timeout again
-      expect(sessionManager.getCategory("session-1")).toBe("category1");
+      // Access via getToolset() - should reset timeout again
+      expect(sessionManager.getToolset("session-1")).toBe("toolset1");
 
       // Wait another 5 seconds
       vi.advanceTimersByTime(5000);
@@ -834,7 +828,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -860,7 +854,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -872,7 +866,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -900,7 +894,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -909,7 +903,7 @@ describe("SessionManager", () => {
       expect(session).toEqual({
         token: "token-1",
         userAgent: "Agent/1.0",
-        category: "category1",
+        toolset: "toolset1",
         transport: mockTransport,
       });
 
@@ -922,14 +916,14 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
       sessionManager.store(
         "session-2",
         "token-2",
         "Agent/2.0",
-        "category2",
+        "toolset2",
         mockTransport2,
       );
 
@@ -948,7 +942,7 @@ describe("SessionManager", () => {
         "session-1",
         "token-1",
         "Agent/1.0",
-        "category1",
+        "toolset1",
         mockTransport,
       );
 
@@ -959,7 +953,7 @@ describe("SessionManager", () => {
       sessionManager.has("session-1");
       sessionManager.get("session-1");
       sessionManager.getToken("session-1");
-      sessionManager.getCategory("session-1");
+      sessionManager.getToolset("session-1");
 
       // Wait 7 seconds (total 10 from creation, but timeouts were reset)
       vi.advanceTimersByTime(7000);

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,7 +11,7 @@ export interface SessionData {
   [sessionId: string]: {
     token: string;
     userAgent: string;
-    category: string;
+    toolset: string;
     transport: StreamableHTTPServerTransport;
     timeout: NodeJS.Timeout;
   };
@@ -31,13 +31,12 @@ export class SessionManager {
     sessionId: string,
     token: string,
     userAgent: string,
-    category: string,
+    toolset: string,
     transport: StreamableHTTPServerTransport,
   ): void {
     if (this.has(sessionId)) {
       clearTimeout(this.sessions[sessionId].timeout);
-    }
-    {
+    } else {
       metricsService.incrementActiveSessions();
     }
 
@@ -53,12 +52,12 @@ export class SessionManager {
     this.sessions[sessionId] = {
       token,
       userAgent,
-      category,
+      toolset,
       transport,
       timeout,
     };
     console.log(
-      `${getTimestamp()} Stored session data for ${sessionId}: userAgent=${userAgent}, category=${category}, active_session(s)=${this.getActiveCount()}`,
+      `${getTimestamp()} Stored session data for ${sessionId}: userAgent=${userAgent}, toolset=${toolset}, active_session(s)=${this.getActiveCount()}`,
     );
   }
 
@@ -137,11 +136,11 @@ export class SessionManager {
     return undefined;
   }
 
-  getCategory(sessionId: string): string | undefined {
+  getToolset(sessionId: string): string | undefined {
     const session = this.sessions[sessionId];
     if (session) {
       this.resetTimeout(sessionId);
-      return session.category;
+      return session.toolset;
     }
     return undefined;
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,8 +6,8 @@ import { describe, it, expect } from "vitest";
  * for the patterns used in the codebase.
  */
 
-describe("Category Color Generation", () => {
-  const getCategoryColor = (categoryName: string): string => {
+describe("Toolset Color Generation", () => {
+  const getToolsetColor = (toolsetName: string): string => {
     const colors = [
       "#6c757d",
       "#28a745",
@@ -18,23 +18,23 @@ describe("Category Color Generation", () => {
       "#9c27b0",
       "#4caf50",
     ];
-    const hash = categoryName
+    const hash = toolsetName
       .split("")
       .reduce((acc, char) => acc + char.charCodeAt(0), 0);
     return colors[hash % colors.length];
   };
 
-  it("should return consistent colors for the same category name", () => {
-    const categoryName = "admin";
-    const color1 = getCategoryColor(categoryName);
-    const color2 = getCategoryColor(categoryName);
+  it("should return consistent colors for the same toolset name", () => {
+    const toolsetName = "admin";
+    const color1 = getToolsetColor(toolsetName);
+    const color2 = getToolsetColor(toolsetName);
 
     expect(color1).toBe(color2);
   });
 
-  it("should return different colors for different category names", () => {
-    const color1 = getCategoryColor("admin");
-    const color2 = getCategoryColor("user");
+  it("should return different colors for different toolset names", () => {
+    const color1 = getToolsetColor("admin");
+    const color2 = getToolsetColor("user");
 
     // While not guaranteed, different inputs should likely produce different colors
     expect(color1).toMatch(/^#[0-9a-f]{6}$/);
@@ -42,28 +42,28 @@ describe("Category Color Generation", () => {
   });
 
   it("should return valid hex colors", () => {
-    const testCategories = ["admin", "user", "operator", "anonymous"];
+    const testToolsets = ["admin", "user", "operator", "anonymous"];
 
-    testCategories.forEach((category) => {
-      const color = getCategoryColor(category);
+    testToolsets.forEach((toolset) => {
+      const color = getToolsetColor(toolset);
       expect(color).toMatch(/^#[0-9a-f]{6}$/);
     });
   });
 
   it("should handle empty string", () => {
-    const color = getCategoryColor("");
+    const color = getToolsetColor("");
     expect(color).toMatch(/^#[0-9a-f]{6}$/);
   });
 
   it("should handle special characters", () => {
-    const color = getCategoryColor("test-category_123");
+    const color = getToolsetColor("test-toolset_123");
     expect(color).toMatch(/^#[0-9a-f]{6}$/);
   });
 });
 
 describe("Tool Filtering", () => {
-  const filterToolsByCategory = (tools: any[], category: string[]): any[] => {
-    return tools.filter((tool) => category.includes(tool.name));
+  const filterToolsByToolset = (tools: any[], toolset: string[]): any[] => {
+    return tools.filter((tool) => toolset.includes(tool.name));
   };
 
   const mockTools = [
@@ -72,9 +72,9 @@ describe("Tool Filtering", () => {
     { name: "tool3", service: "gateway", size: 300 },
   ];
 
-  it("should filter tools by category correctly", () => {
-    const category = ["tool1", "tool3"];
-    const filtered = filterToolsByCategory(mockTools, category);
+  it("should filter tools by toolset correctly", () => {
+    const toolset = ["tool1", "tool3"];
+    const filtered = filterToolsByToolset(mockTools, toolset);
 
     expect(filtered).toHaveLength(2);
     expect(filtered[0].name).toBe("tool1");
@@ -82,22 +82,22 @@ describe("Tool Filtering", () => {
   });
 
   it("should return empty array when no tools match", () => {
-    const category = ["nonexistent"];
-    const filtered = filterToolsByCategory(mockTools, category);
+    const toolset = ["nonexistent"];
+    const filtered = filterToolsByToolset(mockTools, toolset);
 
     expect(filtered).toHaveLength(0);
   });
 
-  it("should return all tools when category includes all tool names", () => {
-    const category = ["tool1", "tool2", "tool3"];
-    const filtered = filterToolsByCategory(mockTools, category);
+  it("should return all tools when toolset includes all tool names", () => {
+    const toolset = ["tool1", "tool2", "tool3"];
+    const filtered = filterToolsByToolset(mockTools, toolset);
 
     expect(filtered).toHaveLength(3);
   });
 
-  it("should handle empty category array", () => {
-    const category: string[] = [];
-    const filtered = filterToolsByCategory(mockTools, category);
+  it("should handle empty toolset array", () => {
+    const toolset: string[] = [];
+    const filtered = filterToolsByToolset(mockTools, toolset);
 
     expect(filtered).toHaveLength(0);
   });

--- a/src/views/dashboard.test.ts
+++ b/src/views/dashboard.test.ts
@@ -50,7 +50,7 @@ describe("Dashboard View", () => {
         deprecated: false,
       },
     ],
-    allCategories: {
+    allToolsets: {
       admin: ["tool1", "tool2"],
       user: ["tool1"],
       operator: ["tool3"],
@@ -73,10 +73,10 @@ describe("Dashboard View", () => {
     expect(html).toContain("3"); // Should show 3 total tools
   });
 
-  it("should include categories count", () => {
+  it("should include toolsets count", () => {
     const html = renderDashboard(mockDashboardData);
 
-    expect(html).toContain("3"); // Should show 3 categories
+    expect(html).toContain("3"); // Should show 3 toolsets
   });
 
   it("should include service information", () => {
@@ -107,7 +107,7 @@ describe("Dashboard View", () => {
   it("should handle empty tools array", () => {
     const emptyData: DashboardData = {
       allTools: [],
-      allCategories: {},
+      allToolsets: {},
       recordApiQueries: false,
       allowWriteOperations: false,
     };
@@ -129,7 +129,7 @@ describe("Dashboard View", () => {
     const html = renderDashboard(mockDashboardData);
 
     expect(html).toContain('href="/tools"');
-    expect(html).toContain('href="/category"');
+    expect(html).toContain('href="/toolset"');
     expect(html).toContain('href="/services"');
   });
 

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -2,28 +2,28 @@ import { AAPMcpToolDefinition } from "../openapi-loader.js";
 import { renderHeader, getHeaderStyles } from "../header.js";
 import { getLogIcon } from "./utils.js";
 
-interface DashboardData {
+export interface DashboardData {
   allTools: AAPMcpToolDefinition[];
-  allCategories: Record<string, string[]>;
+  allToolsets: Record<string, string[]>;
   recordApiQueries: boolean;
   allowWriteOperations: boolean;
 }
 
 export const renderDashboard = (data: DashboardData): string => {
-  const { allTools, allCategories, recordApiQueries, allowWriteOperations } =
+  const { allTools, allToolsets, recordApiQueries, allowWriteOperations } =
     data;
 
   // Calculate summary statistics
   const totalSize = allTools.reduce((sum, tool) => sum + (tool.size || 0), 0);
 
-  // Calculate category statistics dynamically
-  const categoryStats: Record<
+  // Calculate toolset statistics dynamically
+  const toolsetStats: Record<
     string,
     { tools: AAPMcpToolDefinition[]; size: number }
   > = {};
-  for (const [categoryName, categoryTools] of Object.entries(allCategories)) {
-    const tools = allTools.filter((tool) => categoryTools.includes(tool.name));
-    categoryStats[categoryName] = {
+  for (const [toolsetName, toolsetTools] of Object.entries(allToolsets)) {
+    const tools = allTools.filter((tool) => toolsetTools.includes(tool.name));
+    toolsetStats[toolsetName] = {
       tools,
       size: tools.reduce((sum, tool) => sum + (tool.size || 0), 0),
     };
@@ -126,7 +126,7 @@ export const renderDashboard = (data: DashboardData): string => {
             margin-right: 20px;
         }
         .tools-icon { background: linear-gradient(45deg, #007acc, #0056b3); }
-        .categories-icon { background: linear-gradient(45deg, #28a745, #1e7e34); }
+        .toolsets-icon { background: linear-gradient(45deg, #28a745, #1e7e34); }
         .card-title {
             font-size: 1.8em;
             font-weight: bold;
@@ -179,10 +179,10 @@ export const renderDashboard = (data: DashboardData): string => {
             text-decoration: none;
             color: white;
         }
-        .btn-categories {
+        .btn-toolsets {
             background: linear-gradient(45deg, #28a745, #1e7e34);
         }
-        .btn-categories:hover {
+        .btn-toolsets:hover {
             background: linear-gradient(45deg, #1e7e34, #155724);
             box-shadow: 0 5px 15px rgba(40,167,69,0.4);
         }
@@ -426,26 +426,26 @@ export const renderDashboard = (data: DashboardData): string => {
 
             <div class="card">
                 <div class="card-header">
-                    <div class="card-icon categories-icon">👥</div>
-                    <h2 class="card-title">Categories</h2>
+                    <div class="card-icon toolsets-icon">👥</div>
+                    <h2 class="card-title">Toolsets</h2>
                 </div>
                 <p class="card-description">
-                    Understand the different user categories and their tool access levels. Categories control which tools are available based on user permissions and authentication status.
+                    Understand the different user toolsets and their tool access levels. Toolsets control which tools are available based on user permissions and authentication status.
                 </p>
                 <div class="card-stats">
-                    ${Object.entries(categoryStats)
+                    ${Object.entries(toolsetStats)
                       .map(
-                        ([categoryName, stats]) => `
+                        ([toolsetName, stats]) => `
                     <div class="stat">
                         <div class="stat-number">${stats.tools.length} tools</div>
-                        <div class="stat-label">${categoryName.charAt(0).toUpperCase() + categoryName.slice(1)}</div>
+                        <div class="stat-label">${toolsetName.charAt(0).toUpperCase() + toolsetName.slice(1)}</div>
                     </div>
                     `,
                       )
                       .join("")}
                 </div>
                 <br>
-                <a href="/category" class="btn btn-categories">Explore Categories</a>
+                <a href="/toolset" class="btn btn-toolsets">Explore Toolsets</a>
             </div>
 
             <div class="card">
@@ -510,5 +510,3 @@ export const renderDashboard = (data: DashboardData): string => {
 </body>
 </html>`;
 };
-
-export type { DashboardData };

--- a/src/views/endpoints.ts
+++ b/src/views/endpoints.ts
@@ -9,22 +9,21 @@ export interface EndpointData {
   name: string;
   description: string;
   toolName?: string;
-  categories: string[];
+  toolsets: string[];
   logs: McpToolLogEntry[];
 }
 
 export interface EndpointsOverviewData {
   allTools: AAPMcpToolDefinition[];
   endpointsByService: Record<string, EndpointData[]>;
-  allCategories?: Record<string, string[]>;
-  selectedCategory?: string;
+  allToolsets?: Record<string, string[]>;
+  selectedToolset?: string;
 }
 
 export const renderEndpointsOverview = (
   data: EndpointsOverviewData,
 ): string => {
-  const { allTools, endpointsByService, allCategories, selectedCategory } =
-    data;
+  const { allTools, endpointsByService, allToolsets, selectedToolset } = data;
 
   return `
 <!DOCTYPE html>
@@ -142,13 +141,13 @@ export const renderEndpointsOverview = (
         .sort-indicator.active {
             opacity: 1;
         }
-        .categories {
+        .toolsets {
             display: flex;
             flex-wrap: wrap;
             gap: 4px;
             overflow: hidden;
         }
-        .category-badge {
+        .toolset-badge {
             display: inline-block;
             padding: 4px 10px;
             border-radius: 16px;
@@ -161,71 +160,71 @@ export const renderEndpointsOverview = (
             border: 1px solid transparent;
             box-shadow: 0 1px 3px rgba(0,0,0,0.1);
         }
-        .category-admin {
+        .toolset-admin {
             background-color: #fee2e2;
             color: #dc2626;
             border-color: #fecaca;
         }
-        .category-user {
+        .toolset-user {
             background-color: #dcfce7;
             color: #16a34a;
             border-color: #bbf7d0;
         }
-        .category-anonymous {
+        .toolset-anonymous {
             background-color: #f1f5f9;
             color: #475569;
             border-color: #e2e8f0;
         }
-        .category-unknown {
+        .toolset-unknown {
             background-color: #fef3c7;
             color: #d97706;
             border-color: #fde68a;
         }
-        .category-system_monitoring {
+        .toolset-system_monitoring {
             background-color: #dbeafe;
             color: #2563eb;
             border-color: #bfdbfe;
         }
-        .category-job_management {
+        .toolset-job_management {
             background-color: #f3e8ff;
             color: #7c3aed;
             border-color: #e9d5ff;
         }
-        .category-credential_management {
+        .toolset-credential_management {
             background-color: #fdf4ff;
             color: #c026d3;
             border-color: #f5d0fe;
         }
-        .category-badge:hover {
+        .toolset-badge:hover {
             transform: translateY(-1px);
             box-shadow: 0 4px 8px rgba(0,0,0,0.15);
             text-decoration: none;
         }
-        .category-admin:hover {
+        .toolset-admin:hover {
             background-color: #fca5a5;
             border-color: #f87171;
         }
-        .category-user:hover {
+        .toolset-user:hover {
             background-color: #86efac;
             border-color: #4ade80;
         }
-        .category-anonymous:hover {
+        .toolset-anonymous:hover {
             background-color: #cbd5e1;
             border-color: #94a3b8;
         }
-        .category-unknown:hover {
+        .toolset-unknown:hover {
             background-color: #fcd34d;
             border-color: #fbbf24;
         }
-        .category-system_monitoring:hover {
+        .toolset-system_monitoring:hover {
             background-color: #93c5fd;
             border-color: #60a5fa;
         }
-        .category-job_management:hover {
+        .toolset-job_management:hover {
             background-color: #c4b5fd;
             border-color: #a78bfa;
         }
-        .category-credential_management:hover {
+        .toolset-credential_management:hover {
             background-color: #f0abfc;
             border-color: #e879f9;
         }
@@ -453,7 +452,7 @@ export const renderEndpointsOverview = (
                         aVal = a.children[3].textContent;
                         bVal = b.children[3].textContent;
                         break;
-                    case 'categories':
+                    case 'toolsets':
                         aVal = a.children[4].textContent;
                         bVal = b.children[4].textContent;
                         break;
@@ -492,19 +491,19 @@ export const renderEndpointsOverview = (
 
         document.addEventListener('DOMContentLoaded', setupSorting);
 
-        function filterByCategory(category) {
+        function filterByToolset(toolset) {
             const url = new URL(window.location);
-            if (category) {
-                url.searchParams.set('category', category);
+            if (toolset) {
+                url.searchParams.set('toolset', toolset);
             } else {
-                url.searchParams.delete('category');
+                url.searchParams.delete('toolset');
             }
             window.location.href = url.toString();
         }
 
         function clearFilter() {
             const url = new URL(window.location);
-            url.searchParams.delete('category');
+            url.searchParams.delete('toolset');
             window.location.href = url.toString();
         }
     </script>
@@ -516,17 +515,17 @@ export const renderEndpointsOverview = (
         ${renderHeader()}
 
         ${
-          allCategories
+          allToolsets
             ? `
         <div class="filter-section">
-            <label for="category-filter">Filter by Category:</label>
-            <select id="category-filter" onchange="filterByCategory(this.value)">
-                <option value="">All Categories</option>
-                ${Object.keys(allCategories)
+            <label for="toolset-filter">Filter by Toolset:</label>
+            <select id="toolset-filter" onchange="filterByToolset(this.value)">
+                <option value="">All Toolsets</option>
+                ${Object.keys(allToolsets)
                   .map(
-                    (category) => `
-                    <option value="${category}" ${selectedCategory === category ? "selected" : ""}>
-                        ${category
+                    (toolset) => `
+                    <option value="${toolset}" ${selectedToolset === toolset ? "selected" : ""}>
+                        ${toolset
                           .split("_")
                           .map(
                             (word) =>
@@ -538,7 +537,7 @@ export const renderEndpointsOverview = (
                   )
                   .join("")}
             </select>
-            ${selectedCategory ? '<button onclick="clearFilter()">Clear Filter</button>' : ""}
+            ${selectedToolset ? '<button onclick="clearFilter()">Clear Filter</button>' : ""}
         </div>
         `
             : ""
@@ -575,17 +574,17 @@ export const renderEndpointsOverview = (
                 <span class="sortable-header" data-column="path">Path <span class="sort-indicator">↕</span></span>
                 <span class="sortable-header" data-column="description">Description <span class="sort-indicator">↕</span></span>
                 <span class="sortable-header" data-column="tool">Tool Name <span class="sort-indicator">↕</span></span>
-                <span class="sortable-header" data-column="categories">Categories <span class="sort-indicator">↕</span></span>
+                <span class="sortable-header" data-column="toolsets">Toolsets <span class="sort-indicator">↕</span></span>
                 <span class="sortable-header" data-column="logs">Logs <span class="sort-indicator">↕</span></span>
             </div>
             ${endpoints
               .map((endpoint) => {
-                const categoriesHtml =
-                  endpoint.categories.length > 0
-                    ? endpoint.categories
+                const toolsetsHtml =
+                  endpoint.toolsets.length > 0
+                    ? endpoint.toolsets
                         .map(
                           (cat) =>
-                            `<a href="/category/${cat}" class="category-badge category-${cat}">${cat}</a>`,
+                            `<a href="/toolset/${cat}" class="toolset-badge toolset-${cat}">${cat}</a>`,
                         )
                         .join("")
                     : "";
@@ -620,7 +619,7 @@ export const renderEndpointsOverview = (
                 <span class="path">${endpoint.path}</span>
                 <span class="description">${endpoint.description || "No description available"}</span>
                 <span class="tool-name${!endpoint.toolName ? " empty" : ""}">${toolLink}</span>
-                <span class="categories">${categoriesHtml}</span>
+                <span class="toolsets">${toolsetsHtml}</span>
                 <span class="logs">${logsHtml}</span>
             </div>`;
               })

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -3,17 +3,17 @@ export { renderToolsList, type ToolWithSuccessRate } from "./tools.js";
 export {
   renderToolDetails,
   type LogEntry,
-  type CategoryWithAccess,
+  type ToolsetWithAccess,
   type ToolDetailsData,
 } from "./tool-details.js";
 export { renderLogs, type LogsEntry, type LogsData } from "./logs.js";
 export {
-  renderCategoriesOverview,
-  renderCategoryTools,
-  type CategoryData,
-  type CategoriesOverviewData,
-  type CategoryToolsData,
-} from "./categories.js";
+  renderToolsetsOverview,
+  renderToolsetTools,
+  type ToolsetData,
+  type ToolsetsOverviewData,
+  type ToolsetToolsData,
+} from "./toolsets.js";
 export {
   renderServicesOverview,
   renderServiceTools,

--- a/src/views/tool-details.ts
+++ b/src/views/tool-details.ts
@@ -9,7 +9,7 @@ interface LogEntry {
   response?: any;
 }
 
-interface CategoryWithAccess {
+interface ToolsetWithAccess {
   name: string;
   displayName: string;
   color: string;
@@ -21,7 +21,7 @@ interface ToolDetailsData {
   last10Calls: LogEntry[];
   errorCodeSummary: Record<number, number>;
   chartData: { success: number; error: number };
-  categoriesWithAccess: CategoryWithAccess[];
+  toolsetsWithAccess: ToolsetWithAccess[];
 }
 
 export const renderToolDetails = (data: ToolDetailsData): string => {
@@ -31,7 +31,7 @@ export const renderToolDetails = (data: ToolDetailsData): string => {
     last10Calls,
     errorCodeSummary,
     chartData,
-    categoriesWithAccess,
+    toolsetsWithAccess,
   } = data;
 
   // Helper function to format timestamp for display
@@ -188,22 +188,22 @@ export const renderToolDetails = (data: ToolDetailsData): string => {
             white-space: pre;
             font-size: 0.9em;
         }
-        .categories-section {
+        .toolsets-section {
             background-color: #f0f9ff;
             padding: 20px;
             border-radius: 8px;
             margin-bottom: 30px;
         }
-        .categories-section h2 {
+        .toolsets-section h2 {
             margin-top: 0;
             color: #0369a1;
         }
-        .category-badges {
+        .toolset-badges {
             display: flex;
             gap: 10px;
             flex-wrap: wrap;
         }
-        .category-badge {
+        .toolset-badge {
             padding: 8px 16px;
             border-radius: 20px;
             color: white;
@@ -211,12 +211,12 @@ export const renderToolDetails = (data: ToolDetailsData): string => {
             font-weight: bold;
             transition: opacity 0.3s ease;
         }
-        .category-badge:hover {
+        .toolset-badge:hover {
             opacity: 0.8;
             text-decoration: none;
             color: white;
         }
-        .no-categories {
+        .no-toolsets {
             color: #6c757d;
             font-style: italic;
         }
@@ -586,24 +586,24 @@ export const renderToolDetails = (data: ToolDetailsData): string => {
             </div>
         </div>
 
-        <div class="categories-section">
-            <h2>Available to Categories</h2>
+        <div class="toolsets-section">
+            <h2>Available to Toolsets</h2>
             ${
-              categoriesWithAccess.length > 0
+              toolsetsWithAccess.length > 0
                 ? `
-            <div class="category-badges">
-                ${categoriesWithAccess
+            <div class="toolset-badges">
+                ${toolsetsWithAccess
                   .map(
-                    (category) => `
-                <a href="/category/${category.name}" class="category-badge" style="background-color: ${category.color};">
-                    ${category.displayName}
+                    (toolset) => `
+                <a href="/toolset/${toolset.name}" class="toolset-badge" style="background-color: ${toolset.color};">
+                    ${toolset.displayName}
                 </a>
                 `,
                   )
                   .join("")}
             </div>
             `
-                : '<p class="no-categories">This tool is not available to any category.</p>'
+                : '<p class="no-toolsets">This tool is not available to any toolset.</p>'
             }
         </div>
 
@@ -691,4 +691,4 @@ export const renderToolDetails = (data: ToolDetailsData): string => {
 </html>`;
 };
 
-export type { LogEntry, CategoryWithAccess, ToolDetailsData };
+export type { LogEntry, ToolsetWithAccess, ToolDetailsData };

--- a/src/views/toolsets.ts
+++ b/src/views/toolsets.ts
@@ -1,7 +1,7 @@
 import { AAPMcpToolDefinition } from "../openapi-loader.js";
 import { renderHeader, getHeaderStyles } from "../header.js";
 
-interface CategoryData {
+interface ToolsetData {
   name: string;
   displayName: string;
   description: string;
@@ -11,23 +11,21 @@ interface CategoryData {
   totalSize: number;
 }
 
-interface CategoriesOverviewData {
-  categories: CategoryData[];
+interface ToolsetsOverviewData {
+  toolsets: ToolsetData[];
   allTools: AAPMcpToolDefinition[];
 }
 
-interface CategoryToolsData {
-  categoryName: string;
+interface ToolsetToolsData {
+  toolsetName: string;
   displayName: string;
   filteredTools: AAPMcpToolDefinition[];
   totalSize: number;
-  allCategories: Record<string, string[]>;
+  allToolsets: Record<string, string[]>;
 }
 
-export const renderCategoriesOverview = (
-  data: CategoriesOverviewData,
-): string => {
-  const { categories } = data;
+export const renderToolsetsOverview = (data: ToolsetsOverviewData): string => {
+  const { toolsets } = data;
 
   return `
 <!DOCTYPE html>
@@ -35,7 +33,7 @@ export const renderCategoriesOverview = (
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Categories Overview - AAP MCP</title>
+    <title>Toolsets Overview - AAP MCP</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -56,13 +54,13 @@ export const renderCategoriesOverview = (
             padding-bottom: 10px;
         }
         ${getHeaderStyles()}
-        .category-grid {
+        .toolset-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 20px;
             margin-bottom: 30px;
         }
-        .category-card {
+        .toolset-card {
             border: 2px solid #e9ecef;
             border-radius: 8px;
             padding: 20px;
@@ -71,19 +69,19 @@ export const renderCategoriesOverview = (
             transition: all 0.3s ease;
             cursor: pointer;
         }
-        .category-card:hover {
+        .toolset-card:hover {
             border-color: #007acc;
             box-shadow: 0 4px 8px rgba(0,0,0,0.1);
             transform: translateY(-2px);
             text-decoration: none;
             color: inherit;
         }
-        .category-header {
+        .toolset-header {
             display: flex;
             align-items: center;
             margin-bottom: 15px;
         }
-        .category-icon {
+        .toolset-icon {
             width: 40px;
             height: 40px;
             border-radius: 50%;
@@ -95,17 +93,17 @@ export const renderCategoriesOverview = (
             margin-right: 15px;
             font-size: 1.2em;
         }
-        .category-title {
+        .toolset-title {
             font-size: 1.3em;
             font-weight: bold;
             margin: 0;
         }
-        .category-description {
+        .toolset-description {
             color: #6c757d;
             margin-bottom: 15px;
             line-height: 1.4;
         }
-        .category-stats {
+        .toolset-stats {
             display: flex;
             justify-content: space-between;
             background-color: #f8f9fa;
@@ -128,34 +126,34 @@ export const renderCategoriesOverview = (
 </head>
 <body>
     <div class="container">
-        <h1>Categories Overview</h1>
+        <h1>Toolsets Overview</h1>
 
         ${renderHeader()}
 
         <div class="summary">
             <h2>System Summary</h2>
-            <p>The AAP MCP system uses categories to control tool access based on user permissions. Each category provides a different level of access to the available tools.</p>
+            <p>The AAP MCP system uses toolsets to control tool access based on user permissions. Each toolset provides a different level of access to the available tools.</p>
         </div>
 
-        <div class="category-grid">
-            ${categories
+        <div class="toolset-grid">
+            ${toolsets
               .map(
-                (category) => `
-            <a href="/category/${category.name}" class="category-card">
-                <div class="category-header">
-                    <div class="category-icon" style="background-color: ${category.color};">
-                        ${category.displayName.charAt(0)}
+                (toolset) => `
+            <a href="/toolset/${toolset.name}" class="toolset-card">
+                <div class="toolset-header">
+                    <div class="toolset-icon" style="background-color: ${toolset.color};">
+                        ${toolset.displayName.charAt(0)}
                     </div>
-                    <h3 class="category-title">${category.displayName}</h3>
+                    <h3 class="toolset-title">${toolset.displayName}</h3>
                 </div>
-                <p class="category-description">${category.description}</p>
-                <div class="category-stats">
+                <p class="toolset-description">${toolset.description}</p>
+                <div class="toolset-stats">
                     <div class="stat">
-                        <div class="stat-number">${category.toolCount}</div>
+                        <div class="stat-number">${toolset.toolCount}</div>
                         <div class="stat-label">Tools</div>
                     </div>
                     <div class="stat">
-                        <div class="stat-number">${category.totalSize.toLocaleString()}</div>
+                        <div class="stat-number">${toolset.totalSize.toLocaleString()}</div>
                         <div class="stat-label">Characters</div>
                     </div>
                 </div>
@@ -169,8 +167,8 @@ export const renderCategoriesOverview = (
 </html>`;
 };
 
-export const renderCategoryTools = (data: CategoryToolsData): string => {
-  const { categoryName, displayName, filteredTools, totalSize, allCategories } =
+export const renderToolsetTools = (data: ToolsetToolsData): string => {
+  const { toolsetName, displayName, filteredTools, totalSize, allToolsets } =
     data;
 
   const toolRows = filteredTools
@@ -191,7 +189,7 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${displayName} Category Tools - AAP MCP</title>
+    <title>${displayName} Toolset Tools - AAP MCP</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -211,7 +209,7 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
             border-bottom: 2px solid #007acc;
             padding-bottom: 10px;
         }
-        .category-badge {
+        .toolset-badge {
             display: inline-block;
             background-color: #007acc;
             color: white;
@@ -221,12 +219,12 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
             margin-left: 10px;
         }
         ${getHeaderStyles()}
-        .category-nav {
+        .toolset-nav {
             margin-bottom: 20px;
             padding: 15px 0;
             border-bottom: 1px solid #dee2e6;
         }
-        .category-nav-link {
+        .toolset-nav-link {
             background-color: #6c757d;
             color: white;
             padding: 6px 12px;
@@ -235,10 +233,10 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
             margin-right: 10px;
             font-size: 0.9em;
         }
-        .category-nav-link:hover {
+        .toolset-nav-link:hover {
             background-color: #5a6268;
         }
-        .category-nav-link.active {
+        .toolset-nav-link.active {
             background-color: #007acc;
         }
         table {
@@ -283,22 +281,22 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
 </head>
 <body>
     <div class="container">
-        <h1>${displayName} Category Tools<span class="category-badge">${filteredTools.length} tools</span></h1>
+        <h1>${displayName} Toolset Tools<span class="toolset-badge">${filteredTools.length} tools</span></h1>
 
         ${renderHeader()}
 
-        <div class="category-nav">
-            ${Object.keys(allCategories)
+        <div class="toolset-nav">
+            ${Object.keys(allToolsets)
               .map(
                 (name) => `
-            <a href="/category/${name}" class="category-nav-link ${categoryName === name ? "active" : ""}">${name.charAt(0).toUpperCase() + name.slice(1)}</a>
+            <a href="/toolset/${name}" class="toolset-nav-link ${toolsetName === name ? "active" : ""}">${name.charAt(0).toUpperCase() + name.slice(1)}</a>
             `,
               )
               .join("")}
         </div>
 
         <div class="stats">
-            <strong>Category:</strong> ${displayName}<br>
+            <strong>Toolset:</strong> ${displayName}<br>
             <strong>Available Tools:</strong> ${filteredTools.length}<br>
             <strong>Total Size:</strong> ${totalSize.toLocaleString()} characters
         </div>
@@ -307,7 +305,7 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
           filteredTools.length === 0
             ? `
         <div class="empty-state">
-            <p>No tools are available for the ${displayName} category.</p>
+            <p>No tools are available for the ${displayName} toolset.</p>
         </div>
         `
             : `
@@ -330,4 +328,4 @@ export const renderCategoryTools = (data: CategoryToolsData): string => {
 </html>`;
 };
 
-export type { CategoryData, CategoriesOverviewData, CategoryToolsData };
+export type { ToolsetData, ToolsetsOverviewData, ToolsetToolsData };


### PR DESCRIPTION
Use the same word that we are also using everywhere else now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces all "categories" usage with "toolsets" across config, API routes, UI, logging/metrics, and tests.
> 
> - **Config & Docs**:
>   - Rename YAML key `categories` → `toolsets`; update `aap-mcp.sample.yaml` and `README.md` examples and terminology.
> - **Server/Core**:
>   - Replace category-based logic with toolset-based (`getUserToolset`, `filterToolsByToolset`, `getToolsetForTool`).
>   - Update session storage field `category` → `toolset` and related accessors.
>   - Change MCP routes to toolset forms: `/mcp/{toolset}` and `/{toolset}/mcp`.
> - **UI/Views**:
>   - Update navigation link to `Toolsets` and all pages/components from categories → toolsets (`toolsets.ts`, dashboard, endpoints, tool details).
>   - Adjust filters, badges, and labels in endpoints and dashboards to toolsets.
> - **Logging & Metrics**:
>   - Log entries and metrics labels switch from `category` to `toolset` (Prometheus counters/histograms updated; logger includes `toolset`).
> - **Tests**:
>   - Revise unit tests to reflect toolset terminology and behavior across utils, metrics, session, dashboard, and endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801fd21a5a901dbfa26b71377008d3140edf2d2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->