### PR TITLE
AAP-58281: Instrument MCP Server with Telemetry Calls

### DIFF
--- a/ANALYTICS_USAGE.md
+++ b/ANALYTICS_USAGE.md
@@ -1,0 +1,111 @@
+# Analytics Telemetry Usage
+
+This document describes how the MCP server implements telemetry using Segment analytics.
+
+## Configuration
+
+### Environment Variable (recommended)
+
+```bash
+export ANALYTICS_KEY="your-segment-write-key"
+```
+
+### Configuration File
+
+```yaml
+# aap-mcp.yaml
+analytics_key: "your-segment-write-key-here"
+```
+
+## Events Tracked
+
+### 1. Session Started (`mcp_session_started`)
+
+Tracked when a new MCP session is established.
+
+**Fields:**
+
+- `user_agent` - Client user agent string
+- `sess_id` - Unique session identifier (UUID)
+- `mcp_tool_set` - Name of the specific MCP server instance
+- `process_id` - Unique identifier for the server instance (volatile)
+- `user_unique_id` - Generated from process_id and user access token
+
+**Example:**
+
+```json
+{
+  "event": "mcp_session_started",
+  "properties": {
+    "user_agent": "Claude Desktop/0.7.1",
+    "sess_id": "95f5b3cd-5931-4982-92d1-508f98045918",
+    "mcp_tool_set": "job-management",
+    "process_id": "65236301-c591-402b-a97b-0084c57d5179",
+    "user_unique_id": "b519f181-62f3-4eb7-bf96-6c1a1e9756e0"
+  }
+}
+```
+
+### 2. Tool Called (`mcp_tool_called`)
+
+Tracked for every tool invocation (both successful and failed).
+
+**Fields:**
+
+- `tool_name` - Name of the MCP tool
+- `mcp_tool_set` - Name of the specific MCP server instance
+- `user_agent` - Client user agent string
+- `sess_id` - Session identifier (UUID)
+- `parameter_length` - Size in chars of the input payload
+- `http_status` - Return code of the HTTP request
+- `execution_time_ms` - Tool execution time in milliseconds
+- `user_unique_id` - Generated from process_id and user access token
+
+**Example:**
+
+```json
+{
+  "event": "mcp_tool_called",
+  "properties": {
+    "tool_name": "launch_job_template",
+    "mcp_tool_set": "job-management",
+    "user_agent": "Claude Desktop/0.7.1",
+    "sess_id": "95f5b3cd-5931-4982-92d1-508f98045918",
+    "parameter_length": 245,
+    "http_status": 200,
+    "execution_time_ms": 1500,
+    "user_unique_id": "b519f181-62f3-4eb7-bf96-6c1a1e9756e0"
+  }
+}
+```
+
+### 3. Server Status (`mcp_server_status`)
+
+Tracked every 30 minutes to monitor server health.
+
+**Fields:**
+
+- `process_id` - Unique identifier for the server instance (volatile)
+- `health_status` - Overall health status ("healthy", "degraded", "unhealthy")
+- `active_sessions` - Number of active sessions
+- `uptime_seconds` - Server uptime in seconds
+- `server_version` - Version of the MCP server
+- `container_version` - Version of the container
+- `read_only_mode` - Configuration setting for read-only mode
+
+**Example:**
+
+```json
+{
+  "event": "mcp_server_status",
+  "properties": {
+    "process_id": "65236301-c591-402b-a97b-0084c57d5179",
+    "health_status": "healthy",
+    "active_sessions": 15,
+    "uptime_seconds": 3600,
+    "server_version": "1.0.0",
+    "container_version": "2.6.1-20251111",
+    "read_only_mode": false
+  }
+}
+```

--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -11,6 +11,11 @@
 # Configuration for Prometheus metrics endpoint (defaults to false if not specified)
 # enable_metrics: true
 
+# Configuration for analytics telemetry (using Segment)
+# Required: Provide a valid Segment write key to enable telemetry
+# Lower priority than ANALYTICS_KEY environment variable
+# analytics_key: "your-segment-write-key-here"
+
 # Configuration for base URL (defaults to https://localhost if not specified)
 # Lower priority than BASE_URL environment variable
 # base_url: "https://localhost:8443"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",
+        "@segment/analytics-node": "^2.3.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.5.2",
         "cors": "^2.8.5",
@@ -1014,6 +1015,27 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.2.tgz",
@@ -1517,6 +1539,45 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
+      "integrity": "sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -2173,6 +2234,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -2224,6 +2305,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -2590,6 +2695,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -3545,6 +3659,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3719,6 +3853,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -5328,6 +5471,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.6",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.1",
+    "@segment/analytics-node": "^2.3.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.5.2",
     "cors": "^2.8.5",

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AnalyticsService } from "./analytics.js";
+
+// Create a mock instance that will be shared across all tests
+const mockAnalyticsInstance = {
+  track: vi.fn(),
+  closeAndFlush: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn().mockReturnValue(undefined), // Make sure .on() calls return properly
+};
+
+// Mock the @segment/analytics-node module to return the same instance every time
+vi.mock("@segment/analytics-node", () => {
+  const Analytics = vi.fn(() => mockAnalyticsInstance);
+  return { Analytics };
+});
+
+describe("Analytics Service", () => {
+  let analyticsService: AnalyticsService;
+
+  beforeEach(() => {
+    // Create a new analytics service instance for each test
+    analyticsService = new AnalyticsService();
+    vi.clearAllMocks();
+    // Reset the mock analytics instance methods
+    mockAnalyticsInstance.track.mockClear();
+    mockAnalyticsInstance.closeAndFlush.mockClear();
+    mockAnalyticsInstance.on.mockClear();
+  });
+
+  describe("initialization", () => {
+    it("should initialize with valid write key and start periodic reporting", () => {
+      const writeKey = "test-write-key-123";
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      expect(() =>
+        analyticsService.initialize(
+          writeKey,
+          getActiveSessions,
+          serverVersion,
+          containerVersion,
+          readOnlyMode,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should handle initialization errors gracefully", () => {
+      const writeKey = ""; // Empty key should not cause throwing
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      expect(() =>
+        analyticsService.initialize(
+          writeKey,
+          getActiveSessions,
+          serverVersion,
+          containerVersion,
+          readOnlyMode,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("event tracking", () => {
+    beforeEach(() => {
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      analyticsService.initialize(
+        "test-key",
+        getActiveSessions,
+        serverVersion,
+        containerVersion,
+        readOnlyMode,
+      );
+    });
+
+    it("should track mcp_session_started event", () => {
+      const sessionId = "session-123";
+      const userAgent = "Test-Agent/1.0";
+      const mcpToolSet = "test-toolset";
+      const userToken = "test-token";
+
+      analyticsService.trackMcpSessionStarted(
+        sessionId,
+        userAgent,
+        mcpToolSet,
+        userToken,
+      );
+
+      // The actual Analytics mock assertion would verify the track method was called
+      // with correct parameters, but since we're mocking it, we just verify
+      // the method completes without error
+      expect(() =>
+        analyticsService.trackMcpSessionStarted(
+          sessionId,
+          userAgent,
+          mcpToolSet,
+          userToken,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should track mcp_tool_called event", () => {
+      const toolName = "test-tool";
+      const mcpToolSet = "test-toolset";
+      const userAgent = "Test-Agent/1.0";
+      const sessionId = "session-123";
+      const parameterLength = 100;
+      const httpStatus = 200;
+      const executionTimeMs = 500;
+      const userToken = "test-token";
+
+      expect(() =>
+        analyticsService.trackMcpToolCalled(
+          toolName,
+          mcpToolSet,
+          userAgent,
+          sessionId,
+          parameterLength,
+          httpStatus,
+          executionTimeMs,
+          userToken,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should track mcp_server_status event", () => {
+      const healthStatus = "healthy" as const;
+      const activeSessions = 10;
+      const serverVersion = "1.0.0";
+      const containerVersion = "1.2.3";
+      const readOnlyMode = false;
+
+      expect(() =>
+        analyticsService.trackMcpServerStatus(
+          healthStatus,
+          activeSessions,
+          serverVersion,
+          containerVersion,
+          readOnlyMode,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("disabled state", () => {
+    it("should silently ignore tracking calls when not initialized", () => {
+      // These should not throw errors even when analytics is not initialized/enabled
+      expect(() =>
+        analyticsService.trackMcpSessionStarted(
+          "session-123",
+          "agent",
+          "toolset",
+        ),
+      ).not.toThrow();
+      expect(() =>
+        analyticsService.trackMcpToolCalled(
+          "tool",
+          "toolset",
+          "agent",
+          "session-123",
+          0,
+          200,
+          0,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        analyticsService.trackMcpServerStatus(
+          "healthy",
+          0,
+          "1.0.0",
+          "unknown",
+          false,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should silently ignore tracking calls after failed initialization", () => {
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      // Initialize with empty key (should fail to enable analytics)
+      analyticsService.initialize(
+        "",
+        getActiveSessions,
+        serverVersion,
+        containerVersion,
+        readOnlyMode,
+      );
+
+      // These should not throw errors even when analytics initialization failed
+      expect(() =>
+        analyticsService.trackMcpSessionStarted(
+          "session-123",
+          "agent",
+          "toolset",
+        ),
+      ).not.toThrow();
+      expect(() =>
+        analyticsService.trackMcpToolCalled(
+          "tool",
+          "toolset",
+          "agent",
+          "session-123",
+          0,
+          200,
+          0,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        analyticsService.trackMcpServerStatus(
+          "healthy",
+          0,
+          "1.0.0",
+          "unknown",
+          false,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("generateUserUniqueId functionality", () => {
+    beforeEach(() => {
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      analyticsService.initialize(
+        "test-key",
+        getActiveSessions,
+        serverVersion,
+        containerVersion,
+        readOnlyMode,
+      );
+    });
+
+    it("should generate consistent user ID for the same token", () => {
+      const userToken = "test-token-123";
+
+      // Clear any calls from initialization (periodic status report)
+      mockAnalyticsInstance.track.mockClear();
+
+      // Track the same session twice with the same token
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        userToken,
+      );
+      analyticsService.trackMcpSessionStarted(
+        "session-2",
+        "agent",
+        "toolset",
+        userToken,
+      );
+
+      // Verify track was called twice (only our calls, not status report)
+      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(2);
+
+      // Get the anonymousId from both calls
+      const firstCall = mockAnalyticsInstance.track.mock.calls[0][0];
+      const secondCall = mockAnalyticsInstance.track.mock.calls[1][0];
+
+      // Both calls should have the same anonymousId
+      expect(firstCall.anonymousId).toBe(secondCall.anonymousId);
+      expect(firstCall.anonymousId).toBeDefined();
+      expect(typeof firstCall.anonymousId).toBe("string");
+    });
+
+    it("should generate different user IDs for different tokens", () => {
+      const userToken1 = "test-token-123";
+      const userToken2 = "test-token-456";
+
+      // Clear any calls from initialization
+      mockAnalyticsInstance.track.mockClear();
+
+      // Track sessions with different tokens
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        userToken1,
+      );
+      analyticsService.trackMcpSessionStarted(
+        "session-2",
+        "agent",
+        "toolset",
+        userToken2,
+      );
+
+      // Verify track was called twice
+      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(2);
+
+      // Get the anonymousId from both calls
+      const firstCall = mockAnalyticsInstance.track.mock.calls[0][0];
+      const secondCall = mockAnalyticsInstance.track.mock.calls[1][0];
+
+      // Both calls should have different anonymousIds
+      expect(firstCall.anonymousId).not.toBe(secondCall.anonymousId);
+      expect(firstCall.anonymousId).toBeDefined();
+      expect(secondCall.anonymousId).toBeDefined();
+    });
+
+    it("should generate UUID-like format for user ID", () => {
+      const userToken = "test-token-123";
+
+      // Clear any calls from initialization
+      mockAnalyticsInstance.track.mockClear();
+
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        userToken,
+      );
+
+      // Get the anonymousId from the call
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      const anonymousId = call.anonymousId;
+
+      // Should match UUID format: xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-a[0-9a-f]{3}-[0-9a-f]{12}$/;
+      expect(anonymousId).toMatch(uuidRegex);
+    });
+
+    it("should handle undefined user token gracefully", () => {
+      // Clear any calls from initialization
+      mockAnalyticsInstance.track.mockClear();
+
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        undefined,
+      );
+
+      // Should still work without throwing
+      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(1);
+
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.anonymousId).toBeDefined();
+    });
+  });
+
+  describe("shutdown", () => {
+    it("should handle shutdown gracefully", async () => {
+      const getActiveSessions = () => 0;
+      const serverVersion = "1.0.0";
+      const containerVersion = "test";
+      const readOnlyMode = false;
+
+      analyticsService.initialize(
+        "test-key",
+        getActiveSessions,
+        serverVersion,
+        containerVersion,
+        readOnlyMode,
+      );
+      await expect(analyticsService.shutdown()).resolves.not.toThrow();
+    });
+
+    it("should handle shutdown when not initialized", async () => {
+      await expect(analyticsService.shutdown()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,296 @@
+import { Analytics } from "@segment/analytics-node";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Analytics service for MCP server telemetry using Segment
+ */
+export class AnalyticsService {
+  private analytics: Analytics | null = null;
+  private isEnabled = false;
+  private processId: string;
+  private startTime: number;
+  private statusReportInterval: NodeJS.Timeout | null = null;
+
+  constructor() {
+    // Generate volatile process ID that changes on each restart
+    this.processId = randomUUID();
+    this.startTime = Date.now();
+  }
+
+  /**
+   * Initialize analytics with the provided write key and start periodic status reporting
+   * @param writeKey - Segment write key from configuration (already validated and trimmed)
+   * @param getActiveSessions - Function to get the current active session count
+   * @param serverVersion - Version of the MCP server
+   * @param containerVersion - Version of the container
+   * @param readOnlyMode - Configuration setting for read_only mode
+   */
+  initialize(
+    writeKey: string,
+    getActiveSessions: () => number,
+    serverVersion: string,
+    containerVersion: string,
+    readOnlyMode: boolean,
+  ): void {
+    try {
+      this.analytics = new Analytics({
+        writeKey,
+      });
+      console.log("Analytics: Telemetry initialized successfully");
+
+      // this.analytics.on("track", (ctx) =>
+      //   console.log("Analytics: track:", ctx),
+      // )
+      this.analytics.on("error", (err) =>
+        console.error("Analytics: error:", err),
+      );
+      // this.analytics.on("http_request", (err) =>
+      //   console.error("Analytics: http_request:", err),
+      // );
+      this.isEnabled = true;
+
+      // Start periodic status reporting automatically
+      this.startPeriodicStatusReporting(
+        getActiveSessions,
+        serverVersion,
+        containerVersion,
+        readOnlyMode,
+      );
+    } catch (error) {
+      console.error("Analytics: Failed to initialize telemetry:", error);
+      this.isEnabled = false;
+    }
+  }
+
+  /**
+   * Safely shut down analytics
+   */
+  async shutdown(): Promise<void> {
+    // Clear the periodic status reporting interval
+    if (this.statusReportInterval) {
+      clearInterval(this.statusReportInterval);
+      this.statusReportInterval = null;
+    }
+
+    if (this.analytics) {
+      try {
+        await this.analytics.closeAndFlush();
+        console.log("Analytics: Telemetry shut down successfully");
+      } catch (error) {
+        console.error("Analytics: Error during shutdown:", error);
+      }
+      this.analytics = null;
+      this.isEnabled = false;
+    }
+  }
+
+  /**
+   * Generate user unique ID from user access token
+   * @param userToken - User access token (bearer token)
+   * @returns UUID generated from process ID and token
+   */
+  private generateUserUniqueId(userToken?: string): string {
+    // Generate deterministic UUID from process_id and user token
+    // This ensures same user gets same ID during process lifetime
+    const token = userToken || "anonymous";
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      const char = token.charCodeAt(i);
+      hash = (hash << 5) - hash + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+
+    // Format as UUID-like string
+    const hex = Math.abs(hash).toString(16).padStart(8, "0");
+    return `${hex.substring(0, 8)}-${hex.substring(0, 4)}-4${hex.substring(1, 4)}-a${hex.substring(1, 4)}-${hex.padEnd(12, "0")}`;
+  }
+
+  /**
+   * Track MCP session started event
+   * @param sessionId - Unique session identifier (UUID)
+   * @param userAgent - Client user agent string
+   * @param mcpToolSet - Name of the specific MCP server instance
+   * @param userToken - User access token for generating user_unique_id
+   */
+  trackMcpSessionStarted(
+    sessionId: string,
+    userAgent?: string,
+    mcpToolSet?: string,
+    userToken?: string,
+  ): void {
+    if (!this.isEnabled) return;
+    try {
+      this.analytics!.track({
+        event: "mcp_session_started",
+        anonymousId: this.generateUserUniqueId(userToken),
+        properties: {
+          sess_id: sessionId,
+          user_unique_id: this.generateUserUniqueId(userToken),
+          user_agent: userAgent,
+          mcp_tool_set: mcpToolSet,
+          process_id: this.processId,
+        },
+      });
+    } catch (error) {
+      console.error("Analytics: Error tracking mcp_session_started:", error);
+    }
+  }
+
+  /**
+   * Track MCP tool called event
+   * @param toolName - Name of the MCP tool
+   * @param mcpToolSet - Name of the specific MCP server instance
+   * @param userAgent - Client user agent string
+   * @param sessionId - Session identifier (UUID)
+   * @param parameterLength - Size in chars of the input payload
+   * @param httpStatus - Return code of the http request
+   * @param executionTimeMs - Tool execution time in milliseconds
+   * @param userToken - User access token for generating user_unique_id
+   */
+  trackMcpToolCalled(
+    toolName: string,
+    mcpToolSet: string,
+    userAgent: string,
+    sessionId: string,
+    parameterLength: number,
+    httpStatus: number,
+    executionTimeMs: number,
+    userToken?: string,
+  ): void {
+    if (!this.isEnabled) return;
+    try {
+      this.analytics!.track({
+        event: "mcp_tool_called",
+        anonymousId: this.generateUserUniqueId(userToken),
+        properties: {
+          tool_name: toolName,
+          sess_id: sessionId,
+          user_unique_id: this.generateUserUniqueId(userToken),
+          mcp_tool_set: mcpToolSet,
+          user_agent: userAgent,
+          parameter_length: parameterLength,
+          http_status: httpStatus,
+          execution_time_ms: executionTimeMs,
+        },
+      });
+    } catch (error) {
+      console.error("Analytics: Error tracking mcp_tool_called:", error);
+    }
+  }
+
+  /**
+   * Track MCP server status event (sent every 30 minutes)
+   * @param healthStatus - Overall health status of the server
+   * @param activeSessions - Number of active sessions
+   * @param serverVersion - Version of the MCP server
+   * @param containerVersion - Version of the container
+   * @param readOnlyMode - Configuration setting for read_only mode
+   */
+  trackMcpServerStatus(
+    healthStatus: "healthy" | "degraded" | "unhealthy",
+    activeSessions: number,
+    serverVersion: string,
+    containerVersion: string,
+    readOnlyMode: boolean,
+  ): void {
+    if (!this.isEnabled) return;
+    try {
+      const uptimeSeconds = Math.floor((Date.now() - this.startTime) / 1000);
+
+      this.analytics!.track({
+        event: "mcp_server_status",
+        anonymousId: this.processId,
+        properties: {
+          process_id: this.processId,
+          health_status: healthStatus,
+          active_sessions: activeSessions,
+          uptime_seconds: uptimeSeconds,
+          server_version: serverVersion,
+          container_version: containerVersion,
+          read_only_mode: readOnlyMode,
+        },
+      });
+    } catch (error) {
+      console.error("Analytics: Error tracking mcp_server_status:", error);
+    }
+  }
+
+  /**
+   * Start periodic server status reporting (every 30 minutes)
+   */
+  startPeriodicStatusReporting(
+    getActiveSessions: () => number,
+    serverVersion: string,
+    containerVersion: string,
+    readOnlyMode: boolean,
+  ): NodeJS.Timeout {
+    const reportStatus = () => {
+      try {
+        const activeSessions = getActiveSessions();
+        // For now, we assume healthy status. This could be enhanced to check AAP connectivity
+        const healthStatus = "healthy" as const;
+
+        this.trackMcpServerStatus(
+          healthStatus,
+          activeSessions,
+          serverVersion,
+          containerVersion,
+          readOnlyMode,
+        );
+
+        console.log(
+          `Analytics: Sent periodic status report (${activeSessions} active sessions)`,
+        );
+      } catch (error) {
+        console.error("Analytics: Error in periodic status reporting:", error);
+      }
+    };
+
+    // Send initial status report
+    reportStatus();
+
+    // Schedule periodic reports every 30 minutes
+    this.statusReportInterval = setInterval(reportStatus, 30 * 60 * 1000); // 30 minutes in milliseconds
+
+    console.log(
+      "Analytics: Started periodic status reporting (every 30 minutes)",
+    );
+    return this.statusReportInterval;
+  }
+
+  /**
+   * Get process ID for this instance
+   */
+  getProcessId(): string {
+    return this.processId;
+  }
+}
+
+export interface SessionStartedEvent {
+  user_agent?: string;
+  sess_id: string;
+  mcp_tool_set?: string;
+  process_id: string;
+  user_unique_id: string;
+}
+
+export interface ToolCalledEvent {
+  tool_name: string;
+  mcp_tool_set: string;
+  user_agent: string;
+  sess_id: string;
+  parameter_length: number;
+  http_status: number;
+  execution_time_ms: number;
+  user_unique_id: string;
+}
+
+export interface ServerStatusEvent {
+  process_id: string;
+  health_status: "healthy" | "degraded" | "unhealthy";
+  active_sessions: number;
+  uptime_seconds: number;
+  server_version: string;
+  container_version: string;
+  read_only_mode: boolean;
+}


### PR DESCRIPTION
This PR also addresses AAP-58275.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Segment telemetry with new AnalyticsService, tracks sessions/tools/status, integrates with server config/startup/shutdown, and documents usage.
> 
> - **Telemetry (Segment)**:
>   - Add `AnalyticsService` to emit `mcp_session_started`, `mcp_tool_called`, and periodic `mcp_server_status` events.
>   - Deterministic `anonymousId` generation per process/token; graceful shutdown via `closeAndFlush`.
> - **Server Integration (`src/index.ts`)**:
>   - Read `ANALYTICS_KEY` (env > `aap-mcp.yaml`) and initialize analytics on startup.
>   - Track session start in `storeSessionData` and tool invocations (success/failure) with timing, HTTP status, and parameter length.
>   - Include periodic status reporting and shutdown handling.
> - **Configuration & Docs**:
>   - Add `analytics_key` option to `aap-mcp.sample.yaml`.
>   - New `ANALYTICS_USAGE.md` describing configuration and event schemas.
> - **Tests**:
>   - Add `src/analytics.test.ts` covering initialization, event tracking, ID generation, disabled state, and shutdown.
> - **Dependencies**:
>   - Add `@segment/analytics-node`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce619574f9902b2a1a64a77396fbde0eb1b20485. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->