### PR TITLE
session timeout: increase the value to 20 minutes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ const CONFIG = {
   MCP_PORT: process.env.MCP_PORT ? parseInt(process.env.MCP_PORT, 10) : 3000,
   SESSION_TIMEOUT: process.env.SESSION_TIMEOUT
     ? parseInt(process.env.SESSION_TIMEOUT, 10)
-    : localConfig.session_timeout || 120, // Default to 120 seconds (2 minutes)
+    : localConfig.session_timeout || 1200, // 20 minutes, to accomodate Claude
   ANALYTICS_KEY: (
     process.env.ANALYTICS_KEY ||
     localConfig.analytics_key ||


### PR DESCRIPTION
Claude Code has no way to reconnect when a MCP session is lost.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase default `SESSION_TIMEOUT` from 120s to 1200s (20 minutes) when not provided via env or config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fc1bd7c83590f44f4abda767cd668ba219c6bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->