### PR TITLE
session: return 404 when a session is not found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ const createMcpServer = (): Server => {
     const sessionId = extra?.sessionId;
 
     if (!sessionId || !sessionManager.has(sessionId)) {
-      throw new Error("Invalid or missing session ID");
+      throw new Error("Session not found");
     }
     // Get toolset from session data
     const toolset = sessionManager.getToolset(sessionId);
@@ -297,7 +297,7 @@ const createMcpServer = (): Server => {
     const sessionId = extra?.sessionId;
 
     if (!sessionId || !sessionManager.has(sessionId)) {
-      throw new Error("Invalid or missing session ID");
+      throw new Error("Session not found");
     }
 
     // Generate correlation ID for this request
@@ -583,11 +583,11 @@ const mcpPostHandler = async (
       return;
     } else {
       // Invalid request - no session ID or not initialization request
-      res.status(400).json({
+      res.status(404).json({
         jsonrpc: "2.0",
         error: {
           code: -32000,
-          message: "Bad Request: No valid session ID provided",
+          message: "Session not found",
         },
         id: null,
       });
@@ -617,7 +617,7 @@ const mcpGetHandler = async (req: express.Request, res: express.Response) => {
   const sessionId = req.headers["mcp-session-id"] as string;
 
   if (!sessionId || !sessionManager.has(sessionId)) {
-    res.status(400).send("Invalid or missing session ID");
+    res.status(404).send("Session not found");
     return;
   }
 
@@ -644,7 +644,7 @@ const mcpDeleteHandler = async (
   const sessionId = req.headers["mcp-session-id"] as string;
 
   if (!sessionId || !sessionManager.has(sessionId)) {
-    res.status(400).send("Invalid or missing session ID");
+    res.status(404).send("Session not found");
     return;
   }
 


### PR DESCRIPTION
When the client uses an unknown `Mcp-Session-Id`, the server has to
answer with a `404` error.

See: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unknown or missing MCP sessions now return 404 "Session not found" across handlers and request schemas.
> 
> - **Backend/MCP endpoints**:
>   - `POST /mcp`, `GET /mcp`, `DELETE /mcp`: respond with `404` and "Session not found" when `Mcp-Session-Id` is missing/unknown (was `400`).
> - **Server request handlers**:
>   - In `ListToolsRequestSchema` and `CallToolRequestSchema` handlers within `src/index.ts`, throw "Session not found" when session is invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc69a0bc1e639754843fd85e555710364e29e71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->