### PR TITLE
tool: consolidate the analytics triggering at one single place

### DIFF
--- a/scripts/mock-aap-server.ts
+++ b/scripts/mock-aap-server.ts
@@ -218,7 +218,9 @@ function extractId(pathname: string): number {
 }
 
 const server = http.createServer(
-  (req: http.IncomingMessage, res: http.ServerResponse) => {
+  async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    const waitingDuration = 50 + Math.log(Math.random() * 10) * 1000;
+    await new Promise((resolve) => setTimeout(resolve, waitingDuration));
     // Enable CORS
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader(

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -15,8 +15,6 @@ describe("MetricsService", () => {
   it("should record tool executions", () => {
     metricsService.recordToolExecution(
       "test_tool",
-      "test_service",
-      "test_toolset",
       200,
       0.1, // 100ms
     );
@@ -27,19 +25,14 @@ describe("MetricsService", () => {
   });
 
   it("should record tool errors", () => {
-    metricsService.recordToolError(
-      "test_tool",
-      "test_service",
-      "test_toolset",
-      0,
-    );
+    metricsService.recordToolError("test_tool", 0);
 
     // Verify the metrics exist and can be retrieved
     expect(metricsService.mcpToolErrors).toBeDefined();
   });
 
   it("should set active tools count", () => {
-    metricsService.setActiveTools("test_service", 5);
+    metricsService.setActiveTools(5);
 
     // Verify the metrics exist and can be retrieved
     expect(metricsService.mcpActiveTools).toBeDefined();
@@ -73,20 +66,8 @@ describe("MetricsService", () => {
   });
 
   it("should handle multiple tool executions", () => {
-    metricsService.recordToolExecution(
-      "tool1",
-      "service1",
-      "toolset1",
-      200,
-      0.1,
-    );
-    metricsService.recordToolExecution(
-      "tool2",
-      "service2",
-      "toolset2",
-      500,
-      0.2,
-    );
+    metricsService.recordToolExecution("tool1", 200, 0.1);
+    metricsService.recordToolExecution("tool2", 500, 0.2);
 
     // Verify the metrics exist
     expect(metricsService.mcpToolExecutionsTotal).toBeDefined();
@@ -94,13 +75,7 @@ describe("MetricsService", () => {
   });
 
   it("should handle zero duration", () => {
-    metricsService.recordToolExecution(
-      "test_tool",
-      "test_service",
-      "test_toolset",
-      200,
-      0,
-    );
+    metricsService.recordToolExecution("test_tool", 200, 0);
 
     // Verify the metrics work with zero duration
     expect(metricsService.mcpToolExecutionDuration).toBeDefined();

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -31,14 +31,14 @@ export class MetricsService {
     this.mcpToolExecutionsTotal = new Counter({
       name: "mcp_tool_executions_total",
       help: "Total number of MCP tool executions",
-      labelNames: ["tool_name", "service", "toolset", "status_code"],
+      labelNames: ["tool_name", "status_code"],
       registers: [register],
     });
 
     this.mcpToolExecutionDuration = new Histogram({
       name: "mcp_tool_execution_duration_seconds",
       help: "MCP tool execution duration in seconds",
-      labelNames: ["tool_name", "service", "toolset"],
+      labelNames: ["tool_name"],
       buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
       registers: [register],
     });
@@ -46,14 +46,13 @@ export class MetricsService {
     this.mcpToolErrors = new Counter({
       name: "mcp_tool_errors_total",
       help: "Total number of MCP tool execution errors",
-      labelNames: ["tool_name", "service", "toolset", "status_code"],
+      labelNames: ["tool_name", "status_code"],
       registers: [register],
     });
 
     this.mcpActiveTools = new Gauge({
       name: "mcp_active_tools",
       help: "Number of currently active MCP tools",
-      labelNames: ["service"],
       registers: [register],
     });
 
@@ -72,32 +71,21 @@ export class MetricsService {
 
   recordToolExecution(
     toolName: string,
-    service: string,
-    toolset: string,
     statusCode: number,
     executionTimeMs: number,
   ): void {
-    this.mcpToolExecutionsTotal
-      .labels(toolName, service, toolset, statusCode.toString())
-      .inc();
+    this.mcpToolExecutionsTotal.labels(toolName, statusCode.toString()).inc();
     this.mcpToolExecutionDuration
-      .labels(toolName, service, toolset)
+      .labels(toolName)
       .observe(executionTimeMs / 1000);
   }
 
-  recordToolError(
-    toolName: string,
-    service: string,
-    toolset: string,
-    statusCode: number,
-  ): void {
-    this.mcpToolErrors
-      .labels(toolName, service, toolset, statusCode.toString())
-      .inc();
+  recordToolError(toolName: string, statusCode: number): void {
+    this.mcpToolErrors.labels(toolName, statusCode.toString()).inc();
   }
 
-  setActiveTools(service: string, count: number): void {
-    this.mcpActiveTools.labels(service).set(count);
+  setActiveTools(count: number): void {
+    this.mcpActiveTools.set(count);
   }
 
   incrementActiveSessions(): void {


### PR DESCRIPTION
- use a `always` block to handle the telemetry and metrics.
- also remove the toolset name from the metrics.
- also adjust `scripts/mock-aap-server.ts` to handle asyn the new requests, and add a delay
- drop the `correlationId` which is not used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes analytics/metrics handling for tool calls and simplifies metrics labels/APIs, updating server, tests, and mock server latency.
> 
> - **Telemetry/Tool Calls (`src/index.ts`)**:
>   - Centralize analytics/metrics + logging in a `finally` block for `CallToolRequestSchema`.
>   - Use `token` variable consistently; remove per-request correlation logs.
>   - Record executions via `metricsService.recordToolExecution(tool, status, ms)` and errors via `recordToolError(tool, status)`; log concise summary line.
>   - When metrics enabled, set active tools count with `metricsService.setActiveTools(allToolsets["all"].length)` at startup.
> - **Metrics API (`src/metrics.ts`)**:
>   - Simplify metric labels: drop `service` and `toolset` from `mcp_tool_executions_total`, `mcp_tool_execution_duration`, and `mcp_tool_errors` (now labeled by `tool_name` and optional `status_code`).
>   - Update method signatures: `recordToolExecution(toolName, statusCode, executionTimeMs)`, `recordToolError(toolName, statusCode)`, `setActiveTools(count)`.
> - **Tests (`src/metrics.test.ts`)**:
>   - Update tests to new metrics method signatures and label schema.
> - **Mock Server (`scripts/mock-aap-server.ts`)**:
>   - Make request handler `async` and introduce small randomized delay before handling requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e3ade2215ebee318f62ca630c09846db912a5ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->