### PR TITLE
AAP-58276: analytics: drop invalid events

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -40,7 +40,7 @@ export class AnalyticsService {
 
       // Register validation plugin
       const validationPlugin = createValidationPlugin({
-        dropInvalidEvents: false, // Log warnings but don't drop events
+        dropInvalidEvents: true,
         logger: (message: string, data?: any) => {
           console.error(message, data ? JSON.stringify(data, null, 2) : "");
         },


### PR DESCRIPTION
When an event payload doesn't pass the validation filter, an error is
logged and the event is cancelled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable dropping invalid analytics events by default and add a test ensuring events with extra fields are logged and canceled.
> 
> - **Analytics**:
>   - Initialize validation plugin with `dropInvalidEvents: true` in `src/analytics.ts`.
> - **Tests**:
>   - Add test in `src/analytics-validation-plugin.test.ts` to verify events with extra/unknown fields trigger validation errors and are canceled when `dropInvalidEvents` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6d297ac2f5991ef0ba173ca74ecf861d9623d2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->