### PR TITLE
Add OIDC authentication support for MCP authorization specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,61 @@ The service provides several MCP endpoints:
 
 ### Authentication
 
-Include your AAP token in the Authorization header:
+The server supports two authentication modes:
+
+#### 1. AAP Gateway Token (Default)
+
+The default mode validates Bearer tokens against the AAP Gateway `/api/gateway/v1/me/` endpoint. Include your AAP token in the Authorization header:
 
 ```
 Authorization: Bearer your_aap_token_here
 ```
+
+#### 2. OIDC Authentication
+
+When OIDC is enabled, the server validates tokens via an external OIDC provider (e.g., Red Hat SSO, Keycloak, or any OpenID Connect-compliant identity provider). This follows the [MCP authorization specification](https://modelcontextprotocol.io/specification/latest/basic/authorization) with:
+
+- **RFC 9728** Protected Resource Metadata at `/.well-known/oauth-protected-resource`
+- **OAuth 2.1** with PKCE for the authorization code flow
+- **Token introspection** (RFC 7662) or JWT structure validation
+
+To enable OIDC, add the following to your `aap-mcp.yaml`:
+
+```yaml
+oidc:
+  enabled: true
+  issuer_url: "https://sso.example.com/realms/aap"
+  client_id: "aap-mcp-server"
+  client_secret: "your-client-secret"
+  audience: "http://localhost:3000"
+  scopes:
+    - openid
+    - mcp:tools
+  required_scopes:
+    - mcp:tools
+```
+
+**Configuration fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `enabled` | Yes | Set to `true` to enable OIDC authentication |
+| `issuer_url` | Yes | OIDC provider discovery URL (must support `.well-known/openid-configuration`) |
+| `client_id` | Yes | Client ID registered with the OIDC provider (used for token introspection) |
+| `client_secret` | No | Client secret for token introspection. When omitted, falls back to JWT structure validation |
+| `audience` | No | Expected `aud` claim in tokens. Tokens without a matching audience are rejected |
+| `scopes` | No | Scopes advertised in the Protected Resource Metadata document |
+| `required_scopes` | No | Scopes that must be present in the token for access to be granted |
+
+**Keycloak / Red Hat SSO setup example:**
+
+1. Start Keycloak: `docker run -p 8080:8080 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak start-dev`
+2. Create a client scope `mcp:tools` with "Include in token scope" enabled
+3. Configure an audience mapper on the scope pointing to the MCP server URL
+4. Create a confidential client for the MCP server (for introspection)
+5. Enable Dynamic Client Registration if your MCP clients will use DCR
+
+When OIDC is enabled, MCP clients that support the authorization specification (e.g., VS Code, Cursor) will automatically discover the OIDC provider and initiate the OAuth flow in the browser.
 
 ### Session Management
 
@@ -219,6 +269,17 @@ claude mcp add aap-mcp-inventory -t http http://localhost:3000/mcp/inventory_man
 # Use system monitoring tools
 claude mcp add aap-mcp-monitoring -t http http://localhost:3000/mcp/system_monitoring
 ```
+
+#### Option 4: OIDC Authentication (Browser-based)
+
+With OIDC enabled, compatible MCP clients will handle the OAuth flow automatically:
+
+```bash
+# VS Code / Cursor: Add HTTP server URL - auth happens in browser
+claude mcp add aap-mcp -t http http://localhost:3000/mcp
+```
+
+The client will discover the OIDC provider via the `/.well-known/oauth-protected-resource` endpoint and redirect you to your identity provider to sign in.
 
 ## Available Tools
 

--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -23,6 +23,23 @@
 # Allow write operation (POST, DELETE and PATCH)
 # allow_write_operations: false
 
+# OIDC Authentication Configuration
+# When enabled, the server validates Bearer tokens via the configured OIDC provider
+# instead of the AAP Gateway /me/ endpoint. Follows the MCP authorization spec
+# (RFC 9728 Protected Resource Metadata, OAuth 2.1 with PKCE).
+#
+# oidc:
+#   enabled: true
+#   issuer_url: "https://sso.example.com/realms/aap"        # OIDC provider URL
+#   client_id: "aap-mcp-server"                              # Client ID for token introspection
+#   client_secret: "your-client-secret"                      # Client secret for introspection
+#   audience: "https://aap.example.com"                      # Expected audience in tokens
+#   scopes:                                                  # Scopes advertised in PRM metadata
+#     - openid
+#     - mcp:tools
+#   required_scopes:                                         # Scopes required for access
+#     - mcp:tools
+
 services:
   - name: controller
     # url: "https://custom-controller.example.com/api/v2/schema/"

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -1,5 +1,15 @@
 import type { AAPMcpToolDefinition, ServiceConfig } from "./openapi-loader.js";
 
+export interface OidcConfig {
+  enabled: boolean;
+  issuer_url: string;
+  client_id: string;
+  client_secret?: string;
+  scopes?: string[];
+  audience?: string;
+  required_scopes?: string[];
+}
+
 export interface AapMcpConfig {
   record_api_queries?: boolean;
   "ignore-certificate-errors"?: boolean;
@@ -10,6 +20,7 @@ export interface AapMcpConfig {
   services?: ServiceConfig[];
   toolsets: Record<string, string[]>;
   analytics_key?: string;
+  oidc?: OidcConfig;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import {
 import { SessionManager } from "./session.js";
 import { AnalyticsService } from "./analytics.js";
 import { AapMcpConfig, loadToolsetsFromCfg } from "./config-utils.js";
+import {
+  OidcTokenVerifier,
+  buildProtectedResourceMetadata,
+} from "./oidc.js";
 
 // Load environment variables
 config();
@@ -60,6 +64,12 @@ const CONFIG = {
 
 // Initialize analytics service (always instantiated, but only enabled if key provided)
 const analyticsService = new AnalyticsService();
+
+// OIDC configuration
+const oidcConfig = localConfig.oidc;
+const oidcEnabled =
+  oidcConfig?.enabled === true && !!oidcConfig?.issuer_url;
+let oidcVerifier: OidcTokenVerifier | null = null;
 
 // Helper function to get boolean configuration with environment variable override
 const getBooleanConfig = (
@@ -114,8 +124,10 @@ const extractBearerToken = (
     : undefined;
 };
 
-// Validate authorization token
-const validateToken = async (bearerToken: string): Promise<void> => {
+// Validate authorization token via AAP Gateway (legacy mode)
+const validateTokenViaGateway = async (
+  bearerToken: string,
+): Promise<void> => {
   try {
     const response = await fetch(`${CONFIG.BASE_URL}/api/gateway/v1/me/`, {
       headers: {
@@ -129,14 +141,32 @@ const validateToken = async (bearerToken: string): Promise<void> => {
         `Authentication failed: ${response.status} ${response.statusText}`,
       );
     }
-
-    // Token is valid, no need to extract user data
   } catch (error) {
     console.error(`${getTimestamp()} Token validation failed:`, error);
     throw new Error(
       `Token validation failed: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },
     );
+  }
+};
+
+// Validate authorization token: OIDC when configured, otherwise AAP Gateway
+const validateToken = async (bearerToken: string): Promise<void> => {
+  if (oidcEnabled && oidcVerifier) {
+    try {
+      await oidcVerifier.verifyAccessToken(bearerToken);
+    } catch (error) {
+      console.error(
+        `${getTimestamp()} OIDC token verification failed:`,
+        error,
+      );
+      throw new Error(
+        `OIDC token verification failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  } else {
+    await validateTokenViaGateway(bearerToken);
   }
 };
 
@@ -444,6 +474,15 @@ app.use(
   }),
 );
 
+// RFC 9728 Protected Resource Metadata endpoint (OIDC mode)
+if (oidcEnabled && oidcConfig) {
+  app.get("/.well-known/oauth-protected-resource", (_req, res) => {
+    const serverUrl = `http://localhost:${CONFIG.MCP_PORT}`;
+    const metadata = buildProtectedResourceMetadata(serverUrl, oidcConfig);
+    res.json(metadata);
+  });
+}
+
 // MCP POST endpoint handler
 const mcpPostHandler = async (
   req: express.Request,
@@ -466,45 +505,65 @@ const mcpPostHandler = async (
       // Reuse existing transport
       transport = sessionManager.getTransport(sessionId)!;
     } else if (!sessionId && isInitializeRequest(req.body)) {
-      // New initialization request
+      // Reject early if no bearer token is present (before creating transport)
+      const token = extractBearerToken(authHeader);
+      if (!token) {
+        console.warn(`${getTimestamp()} No bearer token provided`);
+        if (oidcEnabled) {
+          const prmUrl = `http://localhost:${CONFIG.MCP_PORT}/.well-known/oauth-protected-resource`;
+          res.setHeader(
+            "WWW-Authenticate",
+            `Bearer realm="aap-mcp", resource_metadata="${prmUrl}"`,
+          );
+        }
+        res.status(401).json({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Authorization required" },
+          id: null,
+        });
+        return;
+      }
+
+      // Validate the token before creating a session
+      try {
+        await validateToken(token);
+      } catch (error) {
+        console.error(
+          `${getTimestamp()} Failed to validate token:`,
+          error,
+        );
+        if (oidcEnabled) {
+          const prmUrl = `http://localhost:${CONFIG.MCP_PORT}/.well-known/oauth-protected-resource`;
+          res.setHeader(
+            "WWW-Authenticate",
+            `Bearer realm="aap-mcp", resource_metadata="${prmUrl}"`,
+          );
+        }
+        res.status(401).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Authentication failed",
+            data: error instanceof Error ? error.message : String(error),
+          },
+          id: null,
+        });
+        return;
+      }
+
+      // New initialization request - token already validated above
+      const validatedToken = token;
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: async (sessionId: string) => {
-          try {
-            // Extract and validate the bearer token
-            const token = extractBearerToken(authHeader);
-            if (token) {
-              try {
-                // Validate token (no permissions extraction)
-                await validateToken(token);
-
-                // Store session data with userAgent, toolset, and transport
-                const userAgent = req.headers["user-agent"] || "unknown";
-                storeSessionData(
-                  sessionId,
-                  token,
-                  userAgent,
-                  toolset,
-                  transport,
-                );
-              } catch (error) {
-                console.error(
-                  `${getTimestamp()} Failed to validate token:`,
-                  error,
-                );
-                // Token validation failed, we cannot create the session without valid token
-                throw error;
-              }
-            } else {
-              console.warn(`${getTimestamp()} No bearer token provided`);
-            }
-          } catch (error) {
-            console.error(
-              `${getTimestamp()} Session init callback failed:`,
-              error,
-            );
-            throw error;
-          }
+          const userAgent = req.headers["user-agent"] || "unknown";
+          storeSessionData(
+            sessionId,
+            validatedToken,
+            userAgent,
+            toolset,
+            transport,
+          );
         },
       });
 
@@ -730,6 +789,26 @@ if (enableMetrics) {
 }
 
 async function main(): Promise<void> {
+  // Initialize OIDC verifier if configured
+  if (oidcEnabled && oidcConfig) {
+    const serverUrl = `http://localhost:${CONFIG.MCP_PORT}`;
+    oidcVerifier = new OidcTokenVerifier(oidcConfig, serverUrl);
+    try {
+      await oidcVerifier.initialize();
+      console.log(
+        `${getTimestamp()} OIDC authentication initialized (issuer: ${oidcConfig.issuer_url})`,
+      );
+    } catch (error) {
+      console.error(
+        `${getTimestamp()} WARNING: Failed to initialize OIDC - falling back to Gateway token validation`,
+      );
+      console.error(
+        `${getTimestamp()}   ${error instanceof Error ? error.message : String(error)}`,
+      );
+      oidcVerifier = null;
+    }
+  }
+
   // Print startup banner
   console.log("");
   console.log("═══════════════════════════════════════════════════════════");
@@ -749,6 +828,9 @@ async function main(): Promise<void> {
     `  Certificate validation: ${ignoreCertificateErrors ? "DISABLED" : "ENABLED"}`,
   );
   console.log(`  Metrics: ${enableMetrics ? "ENABLED" : "DISABLED"}`);
+  console.log(
+    `  Authentication: ${oidcEnabled && oidcVerifier ? `OIDC (${oidcConfig!.issuer_url})` : "AAP Gateway token"}`,
+  );
   console.log("");
   console.log("───────────────────────────────────────────────────────────");
 

--- a/src/oidc.test.ts
+++ b/src/oidc.test.ts
@@ -1,0 +1,611 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  OidcTokenVerifier,
+  buildProtectedResourceMetadata,
+} from "./oidc.js";
+import type { OidcConfig } from "./config-utils.js";
+
+const mockDiscoveryDoc = {
+  issuer: "https://sso.example.com/realms/aap",
+  authorization_endpoint:
+    "https://sso.example.com/realms/aap/protocol/openid-connect/auth",
+  token_endpoint:
+    "https://sso.example.com/realms/aap/protocol/openid-connect/token",
+  introspection_endpoint:
+    "https://sso.example.com/realms/aap/protocol/openid-connect/token/introspect",
+  jwks_uri: "https://sso.example.com/realms/aap/protocol/openid-connect/certs",
+  registration_endpoint:
+    "https://sso.example.com/realms/aap/clients-registrations/openid-connect",
+  scopes_supported: ["openid", "mcp:tools"],
+  response_types_supported: ["code"],
+};
+
+function createJwt(
+  payload: Record<string, unknown>,
+  header: Record<string, unknown> = { alg: "RS256", typ: "JWT" },
+): string {
+  const encode = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${encode(header)}.${encode(payload)}.fake-signature`;
+}
+
+describe("OidcTokenVerifier", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("initialize", () => {
+    it("should fetch OIDC discovery document", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDiscoveryDoc),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://sso.example.com/realms/aap/.well-known/openid-configuration",
+      );
+
+      const doc = verifier.getDiscoveryDocument();
+      expect(doc).toBeTruthy();
+      expect(doc!.issuer).toBe("https://sso.example.com/realms/aap");
+    });
+
+    it("should try OAuth AS metadata if OIDC discovery fails", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://sso.example.com/realms/aap/.well-known/oauth-authorization-server",
+      );
+    });
+
+    it("should throw when discovery fails for all URLs", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockResolvedValueOnce({ ok: false, status: 404 });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await expect(verifier.initialize()).rejects.toThrow(
+        "Failed to fetch OIDC discovery document",
+      );
+    });
+
+    it("should strip trailing slash from issuer URL", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDiscoveryDoc),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap/",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://sso.example.com/realms/aap/.well-known/openid-configuration",
+      );
+    });
+  });
+
+  describe("verifyAccessToken via introspection", () => {
+    it("should verify a valid token", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test-client",
+              scope: "openid mcp:tools",
+              exp: Math.floor(Date.now() / 1000) + 3600,
+              sub: "user-123",
+              aud: "http://localhost:3000",
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+        audience: "http://localhost:3000",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const result = await verifier.verifyAccessToken("valid-token");
+      expect(result.clientId).toBe("test-client");
+      expect(result.scopes).toContain("openid");
+      expect(result.scopes).toContain("mcp:tools");
+      expect(result.subject).toBe("user-123");
+    });
+
+    it("should reject inactive token", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ active: false }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(verifier.verifyAccessToken("expired-token")).rejects.toThrow(
+        "Token is inactive",
+      );
+    });
+
+    it("should reject token with wrong audience", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test-client",
+              aud: "https://other-server.com",
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+        audience: "http://localhost:3000",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(verifier.verifyAccessToken("wrong-aud-token")).rejects.toThrow(
+        "Audience mismatch",
+      );
+    });
+
+    it("should reject token missing required scopes", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test-client",
+              scope: "openid",
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+        required_scopes: ["mcp:tools"],
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(
+        verifier.verifyAccessToken("limited-scope-token"),
+      ).rejects.toThrow("Missing required scope: mcp:tools");
+    });
+
+    it("should handle introspection endpoint failure", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("Internal server error"),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(verifier.verifyAccessToken("any-token")).rejects.toThrow(
+        "Token introspection failed",
+      );
+    });
+  });
+
+  describe("verifyAccessToken via JWT structure (no introspection)", () => {
+    it("should verify a valid JWT", async () => {
+      const payload = {
+        iss: "https://sso.example.com/realms/aap",
+        aud: "http://localhost:3000",
+        sub: "user-456",
+        azp: "client-app",
+        scope: "openid mcp:tools",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const discoveryWithoutIntrospection = {
+        ...mockDiscoveryDoc,
+        introspection_endpoint: undefined,
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(discoveryWithoutIntrospection),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        audience: "http://localhost:3000",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const result = await verifier.verifyAccessToken(createJwt(payload));
+      expect(result.clientId).toBe("client-app");
+      expect(result.subject).toBe("user-456");
+      expect(result.scopes).toContain("mcp:tools");
+    });
+
+    it("should reject expired JWT", async () => {
+      const payload = {
+        iss: "https://sso.example.com/realms/aap",
+        sub: "user-456",
+        exp: Math.floor(Date.now() / 1000) - 3600,
+      };
+
+      const discoveryWithoutIntrospection = {
+        ...mockDiscoveryDoc,
+        introspection_endpoint: undefined,
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(discoveryWithoutIntrospection),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(
+        verifier.verifyAccessToken(createJwt(payload)),
+      ).rejects.toThrow("Token has expired");
+    });
+
+    it("should reject JWT with wrong issuer", async () => {
+      const payload = {
+        iss: "https://evil.example.com/realms/aap",
+        sub: "user-456",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const discoveryWithoutIntrospection = {
+        ...mockDiscoveryDoc,
+        introspection_endpoint: undefined,
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(discoveryWithoutIntrospection),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(
+        verifier.verifyAccessToken(createJwt(payload)),
+      ).rejects.toThrow("Issuer mismatch");
+    });
+
+    it("should reject non-JWT token", async () => {
+      const discoveryWithoutIntrospection = {
+        ...mockDiscoveryDoc,
+        introspection_endpoint: undefined,
+      };
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(discoveryWithoutIntrospection),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      await expect(
+        verifier.verifyAccessToken("not-a-jwt-token"),
+      ).rejects.toThrow("Invalid JWT format");
+    });
+  });
+
+  describe("getOAuthMetadata", () => {
+    it("should return OAuth metadata from discovery", async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockDiscoveryDoc),
+      });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const metadata = verifier.getOAuthMetadata();
+      expect(metadata).toBeTruthy();
+      expect(metadata!.issuer).toBe("https://sso.example.com/realms/aap");
+      expect(metadata!.authorization_endpoint).toContain("auth");
+      expect(metadata!.token_endpoint).toContain("token");
+    });
+
+    it("should return null before initialization", () => {
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      expect(verifier.getOAuthMetadata()).toBeNull();
+    });
+  });
+
+  describe("audience validation", () => {
+    it("should accept array audience with matching entry", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test",
+              aud: ["https://other.com", "http://localhost:3000"],
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+        audience: "http://localhost:3000",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const result = await verifier.verifyAccessToken("valid-token");
+      expect(result.clientId).toBe("test");
+    });
+
+    it("should normalize trailing slashes in audience comparison", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test",
+              aud: "http://localhost:3000/",
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+        audience: "http://localhost:3000",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const result = await verifier.verifyAccessToken("valid-token");
+      expect(result.clientId).toBe("test");
+    });
+
+    it("should skip audience validation when not configured", async () => {
+      global.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockDiscoveryDoc),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              active: true,
+              client_id: "test",
+            }),
+        });
+
+      const config: OidcConfig = {
+        enabled: true,
+        issuer_url: "https://sso.example.com/realms/aap",
+        client_id: "aap-mcp",
+        client_secret: "secret",
+      };
+
+      const verifier = new OidcTokenVerifier(config, "http://localhost:3000");
+      await verifier.initialize();
+
+      const result = await verifier.verifyAccessToken("valid-token");
+      expect(result.clientId).toBe("test");
+    });
+  });
+});
+
+describe("buildProtectedResourceMetadata", () => {
+  it("should build correct PRM document", () => {
+    const config: OidcConfig = {
+      enabled: true,
+      issuer_url: "https://sso.example.com/realms/aap/",
+      client_id: "aap-mcp",
+      scopes: ["openid", "mcp:tools"],
+    };
+
+    const metadata = buildProtectedResourceMetadata(
+      "http://localhost:3000",
+      config,
+    );
+
+    expect(metadata.resource).toBe("http://localhost:3000");
+    expect(metadata.authorization_servers).toEqual([
+      "https://sso.example.com/realms/aap",
+    ]);
+    expect(metadata.scopes_supported).toEqual(["openid", "mcp:tools"]);
+    expect(metadata.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  it("should strip trailing slashes from URLs", () => {
+    const config: OidcConfig = {
+      enabled: true,
+      issuer_url: "https://sso.example.com/realms/aap/",
+      client_id: "aap-mcp",
+    };
+
+    const metadata = buildProtectedResourceMetadata(
+      "http://localhost:3000/",
+      config,
+    );
+
+    expect(metadata.resource).toBe("http://localhost:3000");
+    expect(metadata.authorization_servers).toEqual([
+      "https://sso.example.com/realms/aap",
+    ]);
+  });
+
+  it("should default scopes to openid when not specified", () => {
+    const config: OidcConfig = {
+      enabled: true,
+      issuer_url: "https://sso.example.com/realms/aap",
+      client_id: "aap-mcp",
+    };
+
+    const metadata = buildProtectedResourceMetadata(
+      "http://localhost:3000",
+      config,
+    );
+
+    expect(metadata.scopes_supported).toEqual(["openid"]);
+  });
+});

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -1,0 +1,315 @@
+import type { OidcConfig } from "./config-utils.js";
+
+const getTimestamp = (): string => {
+  return new Date().toISOString().split(".")[0] + "Z";
+};
+
+interface OidcDiscoveryDocument {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  introspection_endpoint?: string;
+  jwks_uri: string;
+  registration_endpoint?: string;
+  scopes_supported?: string[];
+  response_types_supported?: string[];
+  grant_types_supported?: string[];
+}
+
+interface JwksKey {
+  kty: string;
+  kid: string;
+  use?: string;
+  alg?: string;
+  n?: string;
+  e?: string;
+  x5c?: string[];
+}
+
+interface Jwks {
+  keys: JwksKey[];
+}
+
+export interface TokenVerificationResult {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  expiresAt?: number;
+  subject?: string;
+}
+
+export interface OAuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint?: string;
+  introspection_endpoint?: string;
+  response_types_supported: string[];
+}
+
+/**
+ * Resolves OIDC discovery and provides token verification via introspection.
+ *
+ * Follows RFC 9728 (Protected Resource Metadata) and the MCP authorization
+ * specification for third-party IdP integration.
+ */
+export class OidcTokenVerifier {
+  private discoveryDoc: OidcDiscoveryDocument | null = null;
+  private jwks: Jwks | null = null;
+  private config: OidcConfig;
+  private serverUrl: string;
+  private discoveryFetched = false;
+
+  constructor(config: OidcConfig, serverUrl: string) {
+    this.config = config;
+    this.serverUrl = serverUrl;
+  }
+
+  async initialize(): Promise<void> {
+    await this.fetchDiscovery();
+  }
+
+  private async fetchDiscovery(): Promise<void> {
+    if (this.discoveryFetched) return;
+
+    const issuerUrl = this.config.issuer_url.replace(/\/$/, "");
+
+    const urls = [
+      `${issuerUrl}/.well-known/openid-configuration`,
+      `${issuerUrl}/.well-known/oauth-authorization-server`,
+    ];
+
+    for (const url of urls) {
+      try {
+        const response = await fetch(url);
+        if (response.ok) {
+          this.discoveryDoc =
+            (await response.json()) as OidcDiscoveryDocument;
+          this.discoveryFetched = true;
+          console.log(
+            `${getTimestamp()} OIDC discovery loaded from ${url}`,
+          );
+          return;
+        }
+      } catch {
+        // Try next URL
+      }
+    }
+
+    throw new Error(
+      `Failed to fetch OIDC discovery document from issuer: ${issuerUrl}`,
+    );
+  }
+
+  private async fetchJwks(): Promise<Jwks> {
+    if (this.jwks) return this.jwks;
+
+    await this.fetchDiscovery();
+    if (!this.discoveryDoc?.jwks_uri) {
+      throw new Error("No jwks_uri in OIDC discovery document");
+    }
+
+    const response = await fetch(this.discoveryDoc.jwks_uri);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch JWKS: ${response.status}`);
+    }
+
+    this.jwks = (await response.json()) as Jwks;
+    return this.jwks;
+  }
+
+  getDiscoveryDocument(): OidcDiscoveryDocument | null {
+    return this.discoveryDoc;
+  }
+
+  getOAuthMetadata(): OAuthServerMetadata | null {
+    if (!this.discoveryDoc) return null;
+    return {
+      issuer: this.discoveryDoc.issuer,
+      authorization_endpoint: this.discoveryDoc.authorization_endpoint,
+      token_endpoint: this.discoveryDoc.token_endpoint,
+      registration_endpoint: this.discoveryDoc.registration_endpoint,
+      introspection_endpoint: this.discoveryDoc.introspection_endpoint,
+      response_types_supported:
+        this.discoveryDoc.response_types_supported || ["code"],
+    };
+  }
+
+  /**
+   * Verify an access token via the OIDC provider's introspection endpoint.
+   * Falls back to basic JWT structure validation if introspection is unavailable.
+   */
+  async verifyAccessToken(
+    token: string,
+  ): Promise<TokenVerificationResult> {
+    await this.fetchDiscovery();
+
+    if (
+      this.discoveryDoc?.introspection_endpoint &&
+      this.config.client_id &&
+      this.config.client_secret
+    ) {
+      return this.verifyViaIntrospection(token);
+    }
+
+    return this.verifyViaJwtStructure(token);
+  }
+
+  private async verifyViaIntrospection(
+    token: string,
+  ): Promise<TokenVerificationResult> {
+    const endpoint = this.discoveryDoc!.introspection_endpoint!;
+
+    const params = new URLSearchParams({
+      token,
+      client_id: this.config.client_id,
+    });
+
+    if (this.config.client_secret) {
+      params.set("client_secret", this.config.client_secret);
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error(
+        `${getTimestamp()} OIDC introspection failed: ${response.status} ${text}`,
+      );
+      throw new Error(`Token introspection failed: ${response.status}`);
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    if (data.active === false) {
+      throw new Error("Token is inactive");
+    }
+
+    this.validateAudience(data);
+    this.validateRequiredScopes(data);
+
+    return {
+      token,
+      clientId: (data.client_id as string) || "unknown",
+      scopes: (data.scope as string)
+        ? (data.scope as string).split(" ")
+        : [],
+      expiresAt: data.exp as number | undefined,
+      subject: data.sub as string | undefined,
+    };
+  }
+
+  /**
+   * Basic JWT structure validation: decode the payload (without cryptographic
+   * signature verification) and check standard claims. This is a fallback when
+   * introspection is not available.
+   *
+   * For production deployments, configure introspection (client_id + client_secret)
+   * or use the AAP Gateway /me/ endpoint as an additional validation layer.
+   */
+  private async verifyViaJwtStructure(
+    token: string,
+  ): Promise<TokenVerificationResult> {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      throw new Error("Invalid JWT format");
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(
+        Buffer.from(parts[1], "base64url").toString("utf-8"),
+      );
+    } catch {
+      throw new Error("Failed to decode JWT payload");
+    }
+
+    const issuerUrl = this.config.issuer_url.replace(/\/$/, "");
+    const tokenIssuer = (payload.iss as string)?.replace(/\/$/, "");
+    if (tokenIssuer !== issuerUrl) {
+      throw new Error(
+        `Issuer mismatch: expected ${issuerUrl}, got ${tokenIssuer}`,
+      );
+    }
+
+    if (payload.exp && (payload.exp as number) < Math.floor(Date.now() / 1000)) {
+      throw new Error("Token has expired");
+    }
+
+    this.validateAudience(payload);
+    this.validateRequiredScopes(payload);
+
+    return {
+      token,
+      clientId: (payload.azp as string) || (payload.client_id as string) || "unknown",
+      scopes: (payload.scope as string)
+        ? (payload.scope as string).split(" ")
+        : [],
+      expiresAt: payload.exp as number | undefined,
+      subject: payload.sub as string | undefined,
+    };
+  }
+
+  private validateAudience(data: Record<string, unknown>): void {
+    if (!this.config.audience) return;
+
+    const aud = data.aud;
+    const expectedAudience = this.config.audience;
+    const audiences: string[] = Array.isArray(aud)
+      ? (aud as string[])
+      : aud
+        ? [aud as string]
+        : [];
+
+    if (audiences.length === 0) {
+      throw new Error("Token missing audience claim");
+    }
+
+    const normalizedExpected = expectedAudience.replace(/\/$/, "");
+    const matched = audiences.some(
+      (a) => a.replace(/\/$/, "") === normalizedExpected,
+    );
+
+    if (!matched) {
+      throw new Error(
+        `Audience mismatch: expected ${expectedAudience}, got ${audiences.join(", ")}`,
+      );
+    }
+  }
+
+  private validateRequiredScopes(data: Record<string, unknown>): void {
+    const requiredScopes = this.config.required_scopes;
+    if (!requiredScopes || requiredScopes.length === 0) return;
+
+    const tokenScopes = (data.scope as string)
+      ? (data.scope as string).split(" ")
+      : [];
+
+    for (const required of requiredScopes) {
+      if (!tokenScopes.includes(required)) {
+        throw new Error(`Missing required scope: ${required}`);
+      }
+    }
+  }
+}
+
+/**
+ * Build the RFC 9728 Protected Resource Metadata document for this MCP server.
+ */
+export function buildProtectedResourceMetadata(
+  serverUrl: string,
+  oidcConfig: OidcConfig,
+): Record<string, unknown> {
+  const resource = serverUrl.replace(/\/$/, "");
+
+  return {
+    resource,
+    authorization_servers: [oidcConfig.issuer_url.replace(/\/$/, "")],
+    scopes_supported: oidcConfig.scopes || ["openid"],
+    bearer_methods_supported: ["header"],
+  };
+}


### PR DESCRIPTION
## Summary

- Add OpenID Connect (OIDC) authentication as an alternative to the existing AAP Gateway token validation, following the [MCP authorization specification](https://modelcontextprotocol.io/specification/latest/basic/authorization)
- Implement RFC 9728 Protected Resource Metadata endpoint (`/.well-known/oauth-protected-resource`) enabling MCP clients to discover the OIDC provider automatically
- Support token verification via both OIDC introspection (RFC 7662) and JWT structure validation, with configurable audience and scope enforcement
- Fully backward compatible: when OIDC is not configured, the server uses the existing AAP Gateway `/me/` endpoint validation

### New files
| File | Description |
|------|-------------|
| `src/oidc.ts` | OIDC discovery document fetching, token verification (introspection + JWT fallback), audience/scope validation, PRM metadata builder |
| `src/oidc.test.ts` | 21 tests covering discovery, introspection, JWT validation, audience/scope checks, and PRM generation |

### Modified files
| File | Change |
|------|--------|
| `src/config-utils.ts` | `OidcConfig` interface added to `AapMcpConfig` |
| `src/index.ts` | OIDC verifier initialization at startup, PRM endpoint, `WWW-Authenticate` headers on 401 responses, token validation before transport creation |
| `aap-mcp.sample.yaml` | Documented OIDC configuration section |
| `README.md` | OIDC authentication docs with config reference table and Keycloak setup guide |

### Configuration example
```yaml
oidc:
  enabled: true
  issuer_url: "https://sso.example.com/realms/aap"
  client_id: "aap-mcp-server"
  client_secret: "your-client-secret"
  audience: "http://localhost:3000"
  scopes:
    - openid
    - mcp:tools
  required_scopes:
    - mcp:tools
```

## Test plan
- [x] All 21 new OIDC tests pass (discovery, introspection, JWT validation, audience/scope enforcement, PRM metadata)
- [x] All 243 tests pass (including 222 existing tests — no regressions)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean on all modified files
- [ ] Manual test with Keycloak: start Keycloak dev server, configure `aap-mcp.yaml` with OIDC settings, verify token validation via introspection
- [ ] Manual test without OIDC: verify existing AAP Gateway token validation still works when `oidc` section is omitted
- [ ] Manual test with MCP client (VS Code/Cursor): verify PRM discovery and browser-based OAuth flow


Made with [Cursor](https://cursor.com)