### PR TITLE
Add stable pseudonymous telemetry identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ logs/
 
 # Test coverage and results
 coverage/
+test-results/
 test-results.json
-test-results.html
 *.lcov
+
+# IDEs
+.idea/
+
+# Others
+aap-mcp.yaml

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "simulate:mock-aap-server": "tsx ./scripts/mock-aap-server.ts",
     "simulate:mcp-aap-server": "BASE_URL=http://localhost:8080 ENABLE_METRICS=true SESSION_TIMEOUT=30 tsx ./src/index.ts",
     "simulate:horde-of-clients": "tsx ./scripts/simulate-clients.ts --duration 90",
+    "simulate:one-client": "concurrently npm:simulate:mock-aap-server npm:simulate:mcp-aap-server \"tsx ./scripts/simulate-clients.ts --duration 30 --num-clients 1\"",
     "simulate": "concurrently  npm:simulate:mock-aap-server npm:simulate:mcp-aap-server npm:simulate:horde-of-clients",
     "lint": "eslint src --ext .ts,.js",
     "lint:fix": "eslint src --ext .ts,.js --fix"

--- a/scripts/mock-aap-server.ts
+++ b/scripts/mock-aap-server.ts
@@ -32,6 +32,11 @@ const mockUserData = {
   is_platform_auditor: false,
   first_name: "Test",
   last_name: "User",
+  summary_fields: {
+    resource: {
+      ansible_id: "550e8400-e29b-41d4-a716-446655440000",
+    },
+  },
 };
 
 interface PaginatedResponse {

--- a/src/analytics-validation-plugin.test.ts
+++ b/src/analytics-validation-plugin.test.ts
@@ -25,7 +25,9 @@ describe("Analytics Validation Plugin", () => {
       const validEvent = {
         sess_id: "session-123",
         process_id: "process-456",
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
         user_agent: "TestAgent/1.0",
         mcp_tool_set: "test-toolset",
       };
@@ -36,7 +38,7 @@ describe("Analytics Validation Plugin", () => {
     it("should reject event with missing required fields", () => {
       const invalidEvent = {
         user_agent: "TestAgent/1.0",
-        // Missing sess_id, process_id, user_unique_id
+        // Missing sess_id, process_id, user_pseudo_id, user_type
       };
 
       expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
@@ -46,7 +48,9 @@ describe("Analytics Validation Plugin", () => {
       const invalidEvent = {
         sess_id: 123, // Should be string
         process_id: "process-456",
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
@@ -56,7 +60,9 @@ describe("Analytics Validation Plugin", () => {
       const validEvent = {
         sess_id: "session-123",
         process_id: "process-456",
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "external",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateSessionStartedEvent(validEvent)).toBe(true);
@@ -66,8 +72,21 @@ describe("Analytics Validation Plugin", () => {
       const invalidEvent = {
         sess_id: "session-123",
         process_id: "process-456",
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
         unexpected_field: "value",
+      };
+
+      expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
+    });
+
+    it("should reject event with invalid user_type value", () => {
+      const invalidEvent = {
+        sess_id: "session-123",
+        process_id: "process-456",
+        user_pseudo_id: "user-789",
+        user_type: "admin", // Invalid value
       };
 
       expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
@@ -84,7 +103,9 @@ describe("Analytics Validation Plugin", () => {
         parameter_length: 100,
         http_status: 200,
         execution_time_ms: 500,
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "external",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateToolCalledEvent(validEvent)).toBe(true);
@@ -108,7 +129,9 @@ describe("Analytics Validation Plugin", () => {
         parameter_length: 100,
         http_status: 99, // Invalid HTTP status
         execution_time_ms: 500,
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateToolCalledEvent(invalidEvent)).toBe(false);
@@ -123,7 +146,9 @@ describe("Analytics Validation Plugin", () => {
         parameter_length: -10, // Invalid negative value
         http_status: 200,
         execution_time_ms: 500,
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateToolCalledEvent(invalidEvent)).toBe(false);
@@ -138,7 +163,9 @@ describe("Analytics Validation Plugin", () => {
         parameter_length: 100,
         http_status: 200,
         execution_time_ms: -100, // Invalid negative value
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "internal",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateToolCalledEvent(invalidEvent)).toBe(false);
@@ -153,7 +180,9 @@ describe("Analytics Validation Plugin", () => {
         parameter_length: 0,
         http_status: 599, // Valid edge case
         execution_time_ms: 0,
-        user_unique_id: "user-789",
+        user_pseudo_id: "user-789",
+        user_type: "external",
+        installer_pseudo_id: "installer-abc",
       };
 
       expect(validateToolCalledEvent(validEvent)).toBe(true);
@@ -274,7 +303,9 @@ describe("Analytics Validation Plugin", () => {
             properties: {
               sess_id: "session-123",
               process_id: "process-456",
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "internal",
+              installer_pseudo_id: "installer-abc",
             },
           },
         };
@@ -347,7 +378,9 @@ describe("Analytics Validation Plugin", () => {
             properties: {
               sess_id: "session-123",
               process_id: "process-456",
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "internal",
+              installer_pseudo_id: "installer-abc",
               extra_field: "this should not be here",
               another_extra_field: "neither should this",
               numeric_extra: 123,
@@ -398,7 +431,9 @@ describe("Analytics Validation Plugin", () => {
             properties: {
               sess_id: "session-123",
               process_id: "process-456",
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "external",
+              installer_pseudo_id: "installer-abc",
             },
           },
         };
@@ -476,7 +511,9 @@ describe("Analytics Validation Plugin", () => {
               parameter_length: "not-a-number", // Invalid type
               http_status: 200,
               execution_time_ms: 500,
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "internal",
+              installer_pseudo_id: "installer-abc",
             },
           },
         };
@@ -653,7 +690,9 @@ describe("Analytics Validation Plugin", () => {
               parameter_length: 100,
               http_status: status,
               execution_time_ms: 500,
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "internal",
+              installer_pseudo_id: "installer-abc",
             },
           },
         };
@@ -681,7 +720,9 @@ describe("Analytics Validation Plugin", () => {
               parameter_length: 100,
               http_status: status,
               execution_time_ms: 500,
-              user_unique_id: "user-789",
+              user_pseudo_id: "user-789",
+              user_type: "internal",
+              installer_pseudo_id: "installer-abc",
             },
           },
         };
@@ -712,7 +753,9 @@ describe("Analytics Validation Plugin", () => {
             parameter_length: 0, // Zero should be valid
             http_status: 200,
             execution_time_ms: 0, // Zero should be valid
-            user_unique_id: "user-789",
+            user_pseudo_id: "user-789",
+            user_type: "external",
+            installer_pseudo_id: "installer-abc",
           },
         },
       };
@@ -739,7 +782,9 @@ describe("Analytics Validation Plugin", () => {
             parameter_length: -1, // Invalid
             http_status: 99, // Invalid
             execution_time_ms: -1, // Invalid
-            user_unique_id: "", // Invalid
+            user_pseudo_id: "", // Invalid
+            user_type: "admin", // Invalid value
+            installer_pseudo_id: "", // Invalid
             extra_field: "should not be here", // Unexpected
           },
         },
@@ -758,15 +803,17 @@ describe("Analytics Validation Plugin", () => {
             expect.objectContaining({ field: "parameter_length" }),
             expect.objectContaining({ field: "http_status" }),
             expect.objectContaining({ field: "execution_time_ms" }),
-            expect.objectContaining({ field: "user_unique_id" }),
+            expect.objectContaining({ field: "user_pseudo_id" }),
+            expect.objectContaining({ field: "user_type" }),
+            expect.objectContaining({ field: "installer_pseudo_id" }),
             expect.objectContaining({ field: "extra_field" }),
           ]),
         }),
       );
 
-      // Should have detected 9 errors
+      // Should have detected 11 errors
       const logCall = mockLogger.mock.calls[0][1];
-      expect(logCall.errors).toHaveLength(9);
+      expect(logCall.errors).toHaveLength(11);
     });
   });
 });

--- a/src/analytics-validation-plugin.ts
+++ b/src/analytics-validation-plugin.ts
@@ -10,17 +10,27 @@ import {
  */
 const EVENT_SCHEMAS = {
   mcp_session_started: {
-    required: ["sess_id", "process_id", "user_unique_id"],
+    required: [
+      "sess_id",
+      "process_id",
+      "user_pseudo_id",
+      "user_type",
+      "installer_pseudo_id",
+    ],
     optional: ["user_agent", "mcp_tool_set"],
     validators: {
       sess_id: (value: any) => typeof value === "string" && value.length > 0,
       process_id: (value: any) => typeof value === "string" && value.length > 0,
-      user_unique_id: (value: any) =>
+      user_pseudo_id: (value: any) =>
         typeof value === "string" && value.length > 0,
+      user_type: (value: any) =>
+        typeof value === "string" && ["internal", "external"].includes(value),
       user_agent: (value: any) =>
         value === undefined || typeof value === "string",
       mcp_tool_set: (value: any) =>
         value === undefined || typeof value === "string",
+      installer_pseudo_id: (value: any) =>
+        typeof value === "string" && value.length > 0,
     },
   },
   mcp_tool_called: {
@@ -32,7 +42,9 @@ const EVENT_SCHEMAS = {
       "parameter_length",
       "http_status",
       "execution_time_ms",
-      "user_unique_id",
+      "user_pseudo_id",
+      "user_type",
+      "installer_pseudo_id",
     ],
     optional: [],
     validators: {
@@ -47,7 +59,11 @@ const EVENT_SCHEMAS = {
         (value === 0 || (value >= 100 && value < 600)),
       execution_time_ms: (value: any) =>
         typeof value === "number" && value >= 0,
-      user_unique_id: (value: any) =>
+      user_pseudo_id: (value: any) =>
+        typeof value === "string" && value.length > 0,
+      user_type: (value: any) =>
+        typeof value === "string" && ["internal", "external"].includes(value),
+      installer_pseudo_id: (value: any) =>
         typeof value === "string" && value.length > 0,
     },
   },

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -89,24 +89,24 @@ describe("Analytics Service", () => {
       const sessionId = "session-123";
       const userAgent = "Test-Agent/1.0";
       const mcpToolSet = "test-toolset";
-      const userToken = "test-token";
+      const userPseudoId = "abc123def456";
+      const userType = "internal";
 
       analyticsService.trackMcpSessionStarted(
         sessionId,
         userAgent,
         mcpToolSet,
-        userToken,
+        userPseudoId,
+        userType,
       );
 
-      // The actual Analytics mock assertion would verify the track method was called
-      // with correct parameters, but since we're mocking it, we just verify
-      // the method completes without error
       expect(() =>
         analyticsService.trackMcpSessionStarted(
           sessionId,
           userAgent,
           mcpToolSet,
-          userToken,
+          userPseudoId,
+          userType,
         ),
       ).not.toThrow();
     });
@@ -119,7 +119,8 @@ describe("Analytics Service", () => {
       const parameterLength = 100;
       const httpStatus = 200;
       const executionTimeMs = 500;
-      const userToken = "test-token";
+      const userPseudoId = "abc123def456";
+      const userType = "external";
 
       expect(() =>
         analyticsService.trackMcpToolCalled(
@@ -130,7 +131,8 @@ describe("Analytics Service", () => {
           parameterLength,
           httpStatus,
           executionTimeMs,
-          userToken,
+          userPseudoId,
+          userType,
         ),
       ).not.toThrow();
     });
@@ -232,128 +234,109 @@ describe("Analytics Service", () => {
     });
   });
 
-  describe("generateUserUniqueId functionality", () => {
+  describe("user_pseudo_id and user_type in events", () => {
     beforeEach(() => {
       const getActiveSessions = () => 0;
-      const serverVersion = "1.0.0";
-      const containerVersion = "test";
-      const readOnlyMode = false;
-
       analyticsService.initialize(
         "test-key",
         getActiveSessions,
-        serverVersion,
-        containerVersion,
-        readOnlyMode,
+        "1.0.0",
+        "test",
+        false,
       );
+      mockAnalyticsInstance.track.mockClear();
     });
 
-    it("should generate consistent user ID for the same token", () => {
-      const userToken = "test-token-123";
-
-      // Clear any calls from initialization (periodic status report)
-      mockAnalyticsInstance.track.mockClear();
-
-      // Track the same session twice with the same token
+    it("should use provided userPseudoId as anonymousId and in properties", () => {
+      const pseudoId = "abcdef1234567890";
       analyticsService.trackMcpSessionStarted(
         "session-1",
         "agent",
         "toolset",
-        userToken,
-      );
-      analyticsService.trackMcpSessionStarted(
-        "session-2",
-        "agent",
-        "toolset",
-        userToken,
+        pseudoId,
+        "internal",
       );
 
-      // Verify track was called twice (only our calls, not status report)
-      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(2);
-
-      // Get the anonymousId from both calls
-      const firstCall = mockAnalyticsInstance.track.mock.calls[0][0];
-      const secondCall = mockAnalyticsInstance.track.mock.calls[1][0];
-
-      // Both calls should have the same anonymousId
-      expect(firstCall.anonymousId).toBe(secondCall.anonymousId);
-      expect(firstCall.anonymousId).toBeDefined();
-      expect(typeof firstCall.anonymousId).toBe("string");
-    });
-
-    it("should generate different user IDs for different tokens", () => {
-      const userToken1 = "test-token-123";
-      const userToken2 = "test-token-456";
-
-      // Clear any calls from initialization
-      mockAnalyticsInstance.track.mockClear();
-
-      // Track sessions with different tokens
-      analyticsService.trackMcpSessionStarted(
-        "session-1",
-        "agent",
-        "toolset",
-        userToken1,
-      );
-      analyticsService.trackMcpSessionStarted(
-        "session-2",
-        "agent",
-        "toolset",
-        userToken2,
-      );
-
-      // Verify track was called twice
-      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(2);
-
-      // Get the anonymousId from both calls
-      const firstCall = mockAnalyticsInstance.track.mock.calls[0][0];
-      const secondCall = mockAnalyticsInstance.track.mock.calls[1][0];
-
-      // Both calls should have different anonymousIds
-      expect(firstCall.anonymousId).not.toBe(secondCall.anonymousId);
-      expect(firstCall.anonymousId).toBeDefined();
-      expect(secondCall.anonymousId).toBeDefined();
-    });
-
-    it("should generate UUID-like format for user ID", () => {
-      const userToken = "test-token-123";
-
-      // Clear any calls from initialization
-      mockAnalyticsInstance.track.mockClear();
-
-      analyticsService.trackMcpSessionStarted(
-        "session-1",
-        "agent",
-        "toolset",
-        userToken,
-      );
-
-      // Get the anonymousId from the call
-      const call = mockAnalyticsInstance.track.mock.calls[0][0];
-      const anonymousId = call.anonymousId;
-
-      // Should match UUID format: xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx
-      const uuidRegex =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-a[0-9a-f]{3}-[0-9a-f]{12}$/;
-      expect(anonymousId).toMatch(uuidRegex);
-    });
-
-    it("should handle undefined user token gracefully", () => {
-      // Clear any calls from initialization
-      mockAnalyticsInstance.track.mockClear();
-
-      analyticsService.trackMcpSessionStarted(
-        "session-1",
-        "agent",
-        "toolset",
-        undefined,
-      );
-
-      // Should still work without throwing
       expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(1);
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.anonymousId).toBe(pseudoId);
+      expect(call.properties.user_pseudo_id).toBe(pseudoId);
+      expect(call.properties.user_type).toBe("internal");
+    });
+
+    it("should default to anonymous and external when not provided", () => {
+      analyticsService.trackMcpSessionStarted("session-1", "agent", "toolset");
+
+      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(1);
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.anonymousId).toBe("anonymous");
+      expect(call.properties.user_pseudo_id).toBe("anonymous");
+      expect(call.properties.user_type).toBe("external");
+    });
+
+    it("should include user_pseudo_id and user_type in tool called events", () => {
+      analyticsService.trackMcpToolCalled(
+        "tool",
+        "toolset",
+        "agent",
+        "session-1",
+        100,
+        200,
+        500,
+        "pseudo123",
+        "external",
+      );
+
+      expect(mockAnalyticsInstance.track).toHaveBeenCalledTimes(1);
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.anonymousId).toBe("pseudo123");
+      expect(call.properties.user_pseudo_id).toBe("pseudo123");
+      expect(call.properties.user_type).toBe("external");
+    });
+
+    it("should include installer_pseudo_id in session event when provided", () => {
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        "pseudo123",
+        "internal",
+        "installer-pseudo-abc",
+      );
 
       const call = mockAnalyticsInstance.track.mock.calls[0][0];
-      expect(call.anonymousId).toBeDefined();
+      expect(call.properties.installer_pseudo_id).toBe("installer-pseudo-abc");
+    });
+
+    it("should default installer_pseudo_id to 'unknown' when not provided", () => {
+      analyticsService.trackMcpSessionStarted(
+        "session-1",
+        "agent",
+        "toolset",
+        "pseudo123",
+        "internal",
+      );
+
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.properties.installer_pseudo_id).toBe("unknown");
+    });
+
+    it("should include installer_pseudo_id in tool called event when provided", () => {
+      analyticsService.trackMcpToolCalled(
+        "tool",
+        "toolset",
+        "agent",
+        "session-1",
+        100,
+        200,
+        500,
+        "pseudo123",
+        "external",
+        "installer-pseudo-abc",
+      );
+
+      const call = mockAnalyticsInstance.track.mock.calls[0][0];
+      expect(call.properties.installer_pseudo_id).toBe("installer-pseudo-abc");
     });
   });
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -10,15 +10,12 @@ export class AnalyticsService {
   private analytics: Analytics | null = null;
   private isEnabled = false;
   private processId: string;
-  private salt: string;
   private startTime: number;
   private statusReportInterval: NodeJS.Timeout | null = null;
 
   constructor() {
     // Generate volatile process ID that changes on each restart
     this.processId = randomUUID();
-    // Generate secret salt for anonymousId generation
-    this.salt = randomUUID();
     this.startTime = Date.now();
   }
 
@@ -106,48 +103,31 @@ export class AnalyticsService {
   }
 
   /**
-   * Generate user unique ID from user access token and secret salt
-   * @param userToken - User access token (bearer token)
-   * @returns UUID generated from secret salt and token
-   */
-  private generateUserUniqueId(userToken?: string): string {
-    // Generate deterministic UUID from secret salt and user token
-    // This ensures same user gets same ID during process lifetime
-    const token = userToken || "anonymous";
-    const combined = `${this.salt}:${token}`;
-    let hash = 0;
-    for (let i = 0; i < combined.length; i++) {
-      const char = combined.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-
-    // Format as UUID-like string
-    const hex = Math.abs(hash).toString(16).padStart(8, "0");
-    return `${hex.substring(0, 8)}-${hex.substring(0, 4)}-4${hex.substring(1, 4)}-a${hex.substring(1, 4)}-${hex.padEnd(12, "0")}`;
-  }
-
-  /**
    * Track MCP session started event
    * @param sessionId - Unique session identifier (UUID)
    * @param userAgent - Client user agent string
    * @param mcpToolSet - Name of the specific MCP server instance
-   * @param userToken - User access token for generating user_unique_id
+   * @param userPseudoId - HMAC-SHA-256 pseudonymous user identifier
+   * @param userType - User type classification ("internal" | "external")
    */
   trackMcpSessionStarted(
     sessionId: string,
     userAgent?: string,
     mcpToolSet?: string,
-    userToken?: string,
+    userPseudoId: string = "anonymous",
+    userType: string = "external",
+    installerPseudoId: string = "unknown",
   ): void {
     if (!this.isEnabled) return;
     try {
       this.analytics!.track({
         event: "mcp_session_started",
-        anonymousId: this.generateUserUniqueId(userToken),
+        anonymousId: userPseudoId,
         properties: {
           sess_id: sessionId,
-          user_unique_id: this.generateUserUniqueId(userToken),
+          user_pseudo_id: userPseudoId,
+          user_type: userType,
+          installer_pseudo_id: installerPseudoId,
           user_agent: userAgent,
           mcp_tool_set: mcpToolSet,
           process_id: this.processId,
@@ -167,7 +147,8 @@ export class AnalyticsService {
    * @param parameterLength - Size in chars of the input payload
    * @param httpStatus - Return code of the http request
    * @param executionTimeMs - Tool execution time in milliseconds
-   * @param userToken - User access token for generating user_unique_id
+   * @param userPseudoId - HMAC-SHA-256 pseudonymous user identifier
+   * @param userType - User type classification ("internal" | "external")
    */
   trackMcpToolCalled(
     toolName: string,
@@ -177,17 +158,21 @@ export class AnalyticsService {
     parameterLength: number,
     httpStatus: number,
     executionTimeMs: number,
-    userToken?: string,
+    userPseudoId: string = "anonymous",
+    userType: string = "external",
+    installerPseudoId: string = "unknown",
   ): void {
     if (!this.isEnabled) return;
     try {
       this.analytics!.track({
         event: "mcp_tool_called",
-        anonymousId: this.generateUserUniqueId(userToken),
+        anonymousId: userPseudoId,
         properties: {
           tool_name: toolName,
           sess_id: sessionId,
-          user_unique_id: this.generateUserUniqueId(userToken),
+          user_pseudo_id: userPseudoId,
+          user_type: userType,
+          installer_pseudo_id: installerPseudoId,
           mcp_tool_set: mcpToolSet,
           user_agent: userAgent,
           parameter_length: parameterLength,
@@ -295,7 +280,9 @@ export interface SessionStartedEvent {
   sess_id: string;
   mcp_tool_set?: string;
   process_id: string;
-  user_unique_id: string;
+  user_pseudo_id: string;
+  user_type: string;
+  installer_pseudo_id: string;
 }
 
 export interface ToolCalledEvent {
@@ -306,7 +293,9 @@ export interface ToolCalledEvent {
   parameter_length: number;
   http_status: number;
   execution_time_ms: number;
-  user_unique_id: string;
+  user_pseudo_id: string;
+  user_type: string;
+  installer_pseudo_id: string;
 }
 
 export interface ServerStatusEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from "./openapi-loader.js";
 import { SessionManager } from "./session.js";
 import { AnalyticsService } from "./analytics.js";
+import { PseudoIdentityService, type UserInfo } from "./pseudo-identity.js";
 import { AapMcpConfig, loadToolsetsFromCfg } from "./config-utils.js";
 
 // Load environment variables
@@ -60,6 +61,9 @@ const CONFIG = {
 
 // Initialize analytics service (always instantiated, but only enabled if key provided)
 const analyticsService = new AnalyticsService();
+
+// Initialize user identity service for stable pseudonymous telemetry IDs
+const userIdentityService = new PseudoIdentityService();
 
 // Helper function to get boolean configuration with environment variable override
 const getBooleanConfig = (
@@ -115,7 +119,7 @@ const extractBearerToken = (
 };
 
 // Validate authorization token
-const validateToken = async (bearerToken: string): Promise<void> => {
+const validateToken = async (bearerToken: string): Promise<UserInfo> => {
   try {
     const response = await fetch(`${CONFIG.BASE_URL}/api/gateway/v1/me/`, {
       headers: {
@@ -130,7 +134,17 @@ const validateToken = async (bearerToken: string): Promise<void> => {
       );
     }
 
-    // Token is valid, no need to extract user data
+    // Extract user data for stable telemetry identifiers
+    try {
+      const data: any = await response.json();
+      const user = data.results?.[0];
+      return {
+        ansibleId: user?.summary_fields?.resource?.ansible_id,
+        email: user?.email,
+      };
+    } catch {
+      return {};
+    }
   } catch (error) {
     console.error(`${getTimestamp()} Token validation failed:`, error);
     throw new Error(
@@ -146,11 +160,30 @@ const storeSessionData = (
   userAgent: string,
   toolset: string,
   transport: StreamableHTTPServerTransport,
+  userPseudoId: string,
+  userType: string,
+  installerPseudoId: string,
 ): void => {
-  sessionManager.store(sessionId, token, userAgent, toolset, transport);
+  sessionManager.store(
+    sessionId,
+    token,
+    userAgent,
+    toolset,
+    transport,
+    userPseudoId,
+    userType,
+    installerPseudoId,
+  );
 
   // Track session started event
-  analyticsService.trackMcpSessionStarted(sessionId, userAgent, toolset, token);
+  analyticsService.trackMcpSessionStarted(
+    sessionId,
+    userAgent,
+    toolset,
+    userPseudoId,
+    userType,
+    installerPseudoId,
+  );
 };
 
 const deleteSessionData = (sessionId: string): void => {
@@ -401,6 +434,9 @@ const createMcpServer = (): Server => {
         `${getTimestamp()} [toolset:${toolToolset}] ${tool.name} → ${response && response.status} ${response && response.statusText} (${executionTimeMs}ms)`,
       );
 
+      const userPseudoId = sessionManager.getUserPseudoId(sessionId);
+      const userType = sessionManager.getUserType(sessionId);
+      const installerPseudoId = sessionManager.getInstallerPseudoId(sessionId);
       analyticsService.trackMcpToolCalled(
         tool.name,
         toolToolset,
@@ -409,7 +445,9 @@ const createMcpServer = (): Server => {
         parameterLength,
         response ? response.status : 0,
         executionTimeMs,
-        token,
+        userPseudoId,
+        userType,
+        installerPseudoId,
       );
       metricsService.recordToolExecution(
         tool.name,
@@ -475,8 +513,9 @@ const mcpPostHandler = async (
             const token = extractBearerToken(authHeader);
             if (token) {
               try {
-                // Validate token (no permissions extraction)
-                await validateToken(token);
+                // Validate token and extract user info
+                const userInfo = await validateToken(token);
+                const identity = userIdentityService.deriveIdentity(userInfo);
 
                 // Store session data with userAgent, toolset, and transport
                 const userAgent = req.headers["user-agent"] || "unknown";
@@ -486,6 +525,9 @@ const mcpPostHandler = async (
                   userAgent,
                   toolset,
                   transport,
+                  identity.userPseudoId,
+                  identity.userType,
+                  identity.installerPseudoId,
                 );
               } catch (error) {
                 console.error(

--- a/src/pseudo-identity.test.ts
+++ b/src/pseudo-identity.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PseudoIdentityService } from "./pseudo-identity.js";
+
+describe("PseudoIdentityService", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("constructor", () => {
+    it("should use TELEMETRY_HMAC_KEY env var", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-hmac-key-from-env";
+      const service = new PseudoIdentityService();
+      expect(service.isEnabled()).toBe(true);
+      const id = service.generatePseudoId("test-input");
+      expect(id).toHaveLength(64);
+    });
+
+    it("should log warning and be disabled when TELEMETRY_HMAC_KEY is not set", () => {
+      delete process.env.TELEMETRY_HMAC_KEY;
+      const service = new PseudoIdentityService();
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it("should log warning and be disabled when TELEMETRY_HMAC_KEY is empty", () => {
+      process.env.TELEMETRY_HMAC_KEY = "";
+      const service = new PseudoIdentityService();
+      expect(service.isEnabled()).toBe(false);
+    });
+
+    it("should log warning and be disabled when TELEMETRY_HMAC_KEY is whitespace only", () => {
+      process.env.TELEMETRY_HMAC_KEY = "   ";
+      const service = new PseudoIdentityService();
+      expect(service.isEnabled()).toBe(false);
+    });
+  });
+
+  describe("generatePseudoId", () => {
+    let service: PseudoIdentityService;
+
+    beforeEach(() => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key-for-pseudo-id";
+      service = new PseudoIdentityService();
+    });
+
+    it("should return consistent hex string for same input", () => {
+      const id1 = service.generatePseudoId("ansible-id-123");
+      const id2 = service.generatePseudoId("ansible-id-123");
+      expect(id1).toBe(id2);
+    });
+
+    it("should return different hex for different input", () => {
+      const id1 = service.generatePseudoId("ansible-id-123");
+      const id2 = service.generatePseudoId("ansible-id-456");
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should return a 64-character hex string (SHA-256)", () => {
+      const id = service.generatePseudoId("test-input");
+      expect(id).toHaveLength(64);
+      expect(id).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("should produce different output with different keys", () => {
+      process.env.TELEMETRY_HMAC_KEY = "key-one";
+      const service1 = new PseudoIdentityService();
+      const id1 = service1.generatePseudoId("same-input");
+
+      process.env.TELEMETRY_HMAC_KEY = "key-two";
+      const service2 = new PseudoIdentityService();
+      const id2 = service2.generatePseudoId("same-input");
+
+      expect(id1).not.toBe(id2);
+    });
+
+    it("should return 'anonymous' when salt key is not loaded", () => {
+      delete process.env.TELEMETRY_HMAC_KEY;
+      const disabledService = new PseudoIdentityService();
+      expect(disabledService.generatePseudoId("any-input")).toBe("anonymous");
+    });
+  });
+
+  describe("determineUserType", () => {
+    let service: PseudoIdentityService;
+
+    beforeEach(() => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com,ibm.com,ansible.com";
+      service = new PseudoIdentityService();
+    });
+
+    it("should return 'internal' for configured internal domains", () => {
+      expect(service.determineUserType("user@redhat.com")).toBe("internal");
+      expect(service.determineUserType("user@ibm.com")).toBe("internal");
+      expect(service.determineUserType("user@ansible.com")).toBe("internal");
+    });
+
+    it("should return 'external' for non-internal domains", () => {
+      expect(service.determineUserType("user@gmail.com")).toBe("external");
+      expect(service.determineUserType("user@example.com")).toBe("external");
+    });
+
+    it("should be case-insensitive", () => {
+      expect(service.determineUserType("user@REDHAT.COM")).toBe("internal");
+      expect(service.determineUserType("user@RedHat.Com")).toBe("internal");
+    });
+
+    it("should return 'external' when email is undefined", () => {
+      expect(service.determineUserType(undefined)).toBe("external");
+    });
+
+    it("should return 'external' when email is empty", () => {
+      expect(service.determineUserType("")).toBe("external");
+    });
+
+    it("should return 'external' when email is whitespace only", () => {
+      expect(service.determineUserType("   ")).toBe("external");
+    });
+
+    it("should return 'external' for email without @ sign", () => {
+      expect(service.determineUserType("not-an-email")).toBe("external");
+    });
+
+    it("should return 'external' for subdomain of internal domain", () => {
+      expect(service.determineUserType("user@mail.redhat.com")).toBe(
+        "external",
+      );
+      expect(service.determineUserType("user@sub.ibm.com")).toBe("external");
+    });
+
+    it("should handle INTERNAL_EMAIL_DOMAINS with spaces and empty entries", () => {
+      process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com, , ibm.com, ";
+      const svc = new PseudoIdentityService();
+      expect(svc.determineUserType("user@redhat.com")).toBe("internal");
+      expect(svc.determineUserType("user@ibm.com")).toBe("internal");
+      expect(svc.determineUserType("user@gmail.com")).toBe("external");
+    });
+
+    it("should use custom INTERNAL_EMAIL_DOMAINS when set", () => {
+      process.env.INTERNAL_EMAIL_DOMAINS = "custom.org,test.io";
+      const customService = new PseudoIdentityService();
+      expect(customService.determineUserType("user@custom.org")).toBe(
+        "internal",
+      );
+      expect(customService.determineUserType("user@test.io")).toBe("internal");
+      expect(customService.determineUserType("user@redhat.com")).toBe(
+        "external",
+      );
+    });
+
+    it("should return 'external' for all emails when INTERNAL_EMAIL_DOMAINS is not set", () => {
+      delete process.env.INTERNAL_EMAIL_DOMAINS;
+      const svc = new PseudoIdentityService();
+      expect(svc.determineUserType("user@redhat.com")).toBe("external");
+      expect(svc.determineUserType("user@ibm.com")).toBe("external");
+    });
+  });
+
+  describe("deriveIdentity", () => {
+    it("should use ansibleId when available", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({
+        ansibleId: "550e8400-e29b-41d4-a716-446655440000",
+        email: "user@redhat.com",
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.userPseudoId).toHaveLength(64);
+      expect(result!.userType).toBe("internal");
+
+      const fromId = service.generatePseudoId(
+        "550e8400-e29b-41d4-a716-446655440000",
+      );
+      expect(result!.userPseudoId).toBe(fromId);
+    });
+
+    it("should return literal 'anonymous' when ansibleId is missing", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({});
+
+      expect(result).not.toBeNull();
+      expect(result!.userPseudoId).toBe("anonymous");
+      expect(result!.userType).toBe("external");
+    });
+
+    it("should return defaults when salt key is not loaded", () => {
+      delete process.env.TELEMETRY_HMAC_KEY;
+      process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({
+        ansibleId: "some-id",
+        email: "user@redhat.com",
+      });
+
+      expect(result.userPseudoId).toBe("anonymous");
+      expect(result.userType).toBe("internal");
+      expect(result.installerPseudoId).toBe("unknown");
+    });
+
+    it("should set userType to external when email is absent", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({ ansibleId: "some-id" });
+      expect(result!.userType).toBe("external");
+    });
+
+    it("should set userType to internal when email matches internal domain", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({
+        ansibleId: "some-id",
+        email: "user@redhat.com",
+      });
+      expect(result!.userType).toBe("internal");
+    });
+
+    it("should include installerPseudoId when INSTALLER_ID is set", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INSTALLER_ID = "install-uuid-123";
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({ ansibleId: "some-id" });
+      expect(result).not.toBeNull();
+      expect(result!.installerPseudoId).toBeDefined();
+      expect(result!.installerPseudoId).toHaveLength(64);
+    });
+
+    it("should set installerPseudoId to 'unknown' when INSTALLER_ID is not set", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      delete process.env.INSTALLER_ID;
+      const service = new PseudoIdentityService();
+
+      const result = service.deriveIdentity({ ansibleId: "some-id" });
+      expect(result).not.toBeNull();
+      expect(result!.installerPseudoId).toBe("unknown");
+    });
+  });
+
+  describe("getInstallerPseudoId", () => {
+    it("should return HMAC of installer_id when both keys are set", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INSTALLER_ID = "install-uuid-123";
+      const service = new PseudoIdentityService();
+
+      const id = service.getInstallerPseudoId();
+      expect(id).not.toBeNull();
+      expect(id).toHaveLength(64);
+      expect(id).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("should return consistent value for same inputs", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      process.env.INSTALLER_ID = "install-uuid-123";
+      const service = new PseudoIdentityService();
+
+      expect(service.getInstallerPseudoId()).toBe(
+        service.getInstallerPseudoId(),
+      );
+    });
+
+    it("should return 'unknown' when INSTALLER_ID is not set", () => {
+      process.env.TELEMETRY_HMAC_KEY = "test-key";
+      delete process.env.INSTALLER_ID;
+      const service = new PseudoIdentityService();
+
+      expect(service.getInstallerPseudoId()).toBe("unknown");
+    });
+
+    it("should return 'unknown' when TELEMETRY_HMAC_KEY is not set", () => {
+      delete process.env.TELEMETRY_HMAC_KEY;
+      process.env.INSTALLER_ID = "install-uuid-123";
+      const service = new PseudoIdentityService();
+
+      expect(service.getInstallerPseudoId()).toBe("unknown");
+    });
+  });
+});

--- a/src/pseudo-identity.ts
+++ b/src/pseudo-identity.ts
@@ -1,0 +1,141 @@
+import { createHmac } from "node:crypto";
+
+export interface UserInfo {
+  ansibleId?: string;
+  email?: string;
+}
+
+export interface PseudoIdentityResult {
+  userPseudoId: string;
+  userType: string;
+  installerPseudoId: string;
+}
+
+/**
+ * Service for generating stable, privacy-preserving pseudonymous identifiers
+ * using HMAC-SHA-256 with a persistent key.
+ */
+export class PseudoIdentityService {
+  private readonly hmacKey: string | null;
+  private readonly installerId: string | null;
+  private readonly internalEmailDomains: string[];
+
+  constructor() {
+    this.hmacKey = this.loadSaltKey();
+    this.installerId = this.loadInstallerId();
+    this.internalEmailDomains = this.loadInternalEmailDomains();
+  }
+
+  /**
+   * Check if the service is enabled (salt key is loaded).
+   */
+  isEnabled(): boolean {
+    return this.hmacKey !== null;
+  }
+
+  /**
+   * Load salt key from environment variable.
+   */
+  private loadSaltKey(): string | null {
+    const envKey = process.env.TELEMETRY_HMAC_KEY;
+
+    if (!envKey || envKey.trim().length === 0) {
+      console.warn(
+        "PseudoIdentity: TELEMETRY_HMAC_KEY not set — pseudo IDs will not be added to telemetry events",
+      );
+      return null;
+    }
+
+    return envKey.trim();
+  }
+
+  /**
+   * Load installer ID from environment variable.
+   */
+  private loadInstallerId(): string | null {
+    const envId = process.env.INSTALLER_ID;
+
+    if (!envId || envId.trim().length === 0) {
+      console.warn(
+        "PseudoIdentity: INSTALLER_ID not set — installer_pseudo_id will not be added to telemetry events",
+      );
+      return null;
+    }
+
+    return envId.trim();
+  }
+
+  /**
+   * Get the installer pseudo ID (HMAC-SHA-256 of installer_id).
+   * Returns null if either HMAC key or installer ID is missing.
+   */
+  getInstallerPseudoId(): string {
+    if (!this.hmacKey || !this.installerId) {
+      return "unknown";
+    }
+    return this.generatePseudoId(this.installerId);
+  }
+
+  /**
+   * Generate a stable pseudonymous ID using HMAC-SHA-256.
+   * @param identifier - The raw identifier to pseudonymize
+   * @returns 64-character hex string
+   */
+  generatePseudoId(identifier: string): string {
+    if (!this.hmacKey) {
+      return "anonymous";
+    }
+    return createHmac("sha256", this.hmacKey).update(identifier).digest("hex");
+  }
+
+  /**
+   * Load internal email domains from environment variable.
+   */
+  private loadInternalEmailDomains(): string[] {
+    const domainsEnv = process.env.INTERNAL_EMAIL_DOMAINS;
+    if (!domainsEnv || domainsEnv.trim().length === 0) {
+      console.warn(
+        "PseudoIdentity: INTERNAL_EMAIL_DOMAINS not set — all users will be classified as external",
+      );
+      return [];
+    }
+    return domainsEnv
+      .split(",")
+      .map((d) => d.trim().toLowerCase())
+      .filter((d) => d.length > 0);
+  }
+
+  /**
+   * Determine user type based on email domain matching against INTERNAL_EMAIL_DOMAINS.
+   * @param email - User email address (optional)
+   * @returns "internal" | "external"
+   */
+  determineUserType(email?: string): string {
+    if (!email || email.trim().length === 0) {
+      return "external";
+    }
+
+    const lowerEmail = email.toLowerCase();
+    return this.internalEmailDomains.some((domain) =>
+      lowerEmail.endsWith(`@${domain}`),
+    )
+      ? "internal"
+      : "external";
+  }
+
+  /**
+   * Derive complete pseudonymous identity from user info.
+   * Returns defaults for pseudo IDs if the salt key is not loaded.
+   * @param userInfo - User info extracted from /me/ endpoint
+   */
+  deriveIdentity(userInfo: UserInfo): PseudoIdentityResult {
+    const identifier = userInfo.ansibleId;
+    return {
+      userPseudoId: identifier
+        ? this.generatePseudoId(identifier)
+        : "anonymous",
+      userType: this.determineUserType(userInfo.email),
+      installerPseudoId: this.getInstallerPseudoId(),
+    };
+  }
+}

--- a/src/session.test.ts
+++ b/src/session.test.ts
@@ -50,7 +50,16 @@ describe("SessionManager", () => {
       const userAgent = "TestAgent/1.0";
       const toolset = "test-toolset";
 
-      sessionManager.store(sessionId, token, userAgent, toolset, mockTransport);
+      sessionManager.store(
+        sessionId,
+        token,
+        userAgent,
+        toolset,
+        mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
+      );
 
       expect(sessionManager.has(sessionId)).toBe(true);
       expect(sessionManager.get(sessionId)).toEqual({
@@ -58,6 +67,9 @@ describe("SessionManager", () => {
         userAgent,
         toolset,
         transport: mockTransport,
+        userPseudoId: "test-pseudo-id",
+        userType: "external",
+        installerPseudoId: "unknown",
       });
     });
 
@@ -68,6 +80,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(metricsService.incrementActiveSessions).toHaveBeenCalledTimes(1);
@@ -87,6 +102,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(loggedMessage).toMatch(
@@ -103,6 +121,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getActiveCount()).toBe(1);
 
@@ -112,6 +133,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getActiveCount()).toBe(2);
     });
@@ -126,6 +150,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getToken(sessionId)).toBe("token-1");
 
@@ -136,6 +163,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getToken(sessionId)).toBe("token-2");
       expect(sessionManager.getToolset(sessionId)).toBe("toolset2");
@@ -150,6 +180,9 @@ describe("SessionManager", () => {
         userAgent: "Agent/1.0",
         toolset: "toolset1",
         transport: mockTransport,
+        userPseudoId: "test-pseudo-id",
+        userType: "external",
+        installerPseudoId: "unknown",
       };
 
       sessionManager.store(
@@ -158,6 +191,9 @@ describe("SessionManager", () => {
         expectedData.userAgent,
         expectedData.toolset,
         expectedData.transport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.get(sessionId)).toEqual(expectedData);
@@ -176,6 +212,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.has("session-1")).toBe(true);
     });
@@ -198,6 +237,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.has(sessionId)).toBe(true);
@@ -212,6 +254,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.delete("session-1");
 
@@ -228,6 +273,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       console.log = (message: string) => {
@@ -256,6 +304,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -263,6 +314,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getActiveCount()).toBe(2);
 
@@ -286,6 +340,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -293,6 +350,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       const sessionIds = sessionManager.getAllSessionIds();
@@ -308,6 +368,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -315,6 +378,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.getAllSessionIds()).toHaveLength(2);
@@ -340,6 +406,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getActiveCount()).toBe(1);
 
@@ -349,6 +418,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       expect(sessionManager.getActiveCount()).toBe(2);
 
@@ -368,6 +440,9 @@ describe("SessionManager", () => {
         "TestAgent/1.0",
         "test-toolset",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
     });
 
@@ -422,6 +497,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -429,6 +507,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -450,6 +531,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       console.log = (message: string) => {
@@ -480,6 +564,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         errorTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -487,6 +574,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       console.error = (message: string, error?: any) => {
@@ -537,6 +627,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -544,6 +637,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -580,6 +676,9 @@ describe("SessionManager", () => {
         sessionData.userAgent,
         sessionData.toolset,
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Verify all getters return correct data
@@ -588,6 +687,9 @@ describe("SessionManager", () => {
         userAgent: sessionData.userAgent,
         toolset: sessionData.toolset,
         transport: mockTransport,
+        userPseudoId: "test-pseudo-id",
+        userType: "external",
+        installerPseudoId: "unknown",
       });
 
       expect(sessionManager.getToken(sessionData.id)).toBe(sessionData.token);
@@ -611,6 +713,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(defaultSessionManager.getActiveCount()).toBe(1);
@@ -633,6 +738,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(customSessionManager.getActiveCount()).toBe(1);
@@ -660,6 +768,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.has("session-1")).toBe(true);
@@ -685,6 +796,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.has("session-1")).toBe(true);
@@ -704,6 +818,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -711,6 +828,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -730,6 +850,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Wait 5 seconds
@@ -759,6 +882,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Wait 5 seconds
@@ -787,6 +913,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Wait 5 seconds
@@ -832,6 +961,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Manually delete session
@@ -858,6 +990,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Wait 5 seconds
@@ -870,6 +1005,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // clearTimeout should have been called for the old timeout
@@ -898,6 +1036,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       const session = sessionManager.get("session-1");
@@ -907,6 +1048,9 @@ describe("SessionManager", () => {
         userAgent: "Agent/1.0",
         toolset: "toolset1",
         transport: mockTransport,
+        userPseudoId: "test-pseudo-id",
+        userType: "external",
+        installerPseudoId: "unknown",
       });
 
       // Should not contain timeout property
@@ -920,6 +1064,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
       sessionManager.store(
         "session-2",
@@ -927,6 +1074,9 @@ describe("SessionManager", () => {
         "Agent/2.0",
         "toolset2",
         mockTransport2,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       expect(sessionManager.getActiveCount()).toBe(2);
@@ -946,6 +1096,9 @@ describe("SessionManager", () => {
         "Agent/1.0",
         "toolset1",
         mockTransport,
+        "test-pseudo-id",
+        "external",
+        "unknown",
       );
 
       // Wait 3 seconds

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,9 @@ export interface SessionData {
     toolset: string;
     transport: StreamableHTTPServerTransport;
     timeout: NodeJS.Timeout;
+    userPseudoId: string;
+    userType: string;
+    installerPseudoId: string;
   };
 }
 
@@ -33,6 +36,9 @@ export class SessionManager {
     userAgent: string,
     toolset: string,
     transport: StreamableHTTPServerTransport,
+    userPseudoId: string,
+    userType: string,
+    installerPseudoId: string,
   ): void {
     if (this.has(sessionId)) {
       clearTimeout(this.sessions[sessionId].timeout);
@@ -55,6 +61,9 @@ export class SessionManager {
       toolset,
       transport,
       timeout,
+      userPseudoId,
+      userType,
+      installerPseudoId,
     };
     console.log(
       `${getTimestamp()} Stored session data for ${sessionId}: userAgent=${userAgent}, toolset=${toolset}, active_session(s)=${this.getActiveCount()}`,
@@ -161,6 +170,33 @@ export class SessionManager {
       return session.transport;
     }
     return undefined;
+  }
+
+  getInstallerPseudoId(sessionId: string): string {
+    const session = this.sessions[sessionId];
+    if (session) {
+      this.resetTimeout(sessionId);
+      return session.installerPseudoId;
+    }
+    return "unknown";
+  }
+
+  getUserPseudoId(sessionId: string): string {
+    const session = this.sessions[sessionId];
+    if (session) {
+      this.resetTimeout(sessionId);
+      return session.userPseudoId;
+    }
+    return "anonymous";
+  }
+
+  getUserType(sessionId: string): string {
+    const session = this.sessions[sessionId];
+    if (session) {
+      this.resetTimeout(sessionId);
+      return session.userType;
+    }
+    return "external";
   }
 
   // Close all sessions (for graceful shutdown)

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { parse as parseUrl } from "node:url";
+import { copyFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// Use unique ports to avoid conflicts with other running instances
+const MOCK_AAP_PORT = 18080;
+const MCP_SERVER_PORT = 13000;
+const MCP_BASE_URL = `http://localhost:${MCP_SERVER_PORT}`;
+const BEARER_TOKEN = "test-bearer-token";
+
+// Mock user data matching the /me/ endpoint response
+const mockUserData = {
+  id: 1,
+  username: "test-user",
+  email: "test@redhat.com",
+  is_superuser: true,
+  is_platform_auditor: false,
+  first_name: "Test",
+  last_name: "User",
+  summary_fields: {
+    resource: {
+      ansible_id: "550e8400-e29b-41d4-a716-446655440000",
+    },
+  },
+};
+
+let mockAapServer: Server;
+
+/**
+ * Create an MCP client connected to a specific toolset.
+ */
+const createMcpClient = (toolset: string, token?: string) => {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${MCP_BASE_URL}/mcp/${toolset}`),
+    {
+      requestInit: {
+        headers: {
+          ...(token && { Authorization: `Bearer ${token}` }),
+          "User-Agent": "E2E-Test-Client/1.0",
+          "mcp-protocol-version": "2025-06-18",
+        },
+      },
+    },
+  );
+
+  const client = new Client(
+    { name: "e2e-test-client", version: "1.0.0" },
+    {
+      capabilities: { tools: {} },
+      protocolVersion: "2025-06-18",
+    },
+  );
+
+  return { client, transport };
+};
+
+/**
+ * Start a minimal mock AAP server.
+ */
+const startMockAapServer = (): Promise<Server> => {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const parsedUrl = parseUrl(req.url || "", true);
+      const pathname = parsedUrl.pathname || "";
+
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader(
+        "Access-Control-Allow-Methods",
+        "GET, POST, DELETE, OPTIONS",
+      );
+      res.setHeader("Access-Control-Allow-Headers", "*");
+
+      if (req.method === "OPTIONS") {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      if (pathname === "/api/gateway/v1/me/") {
+        // Check for valid bearer token
+        const authHeader = req.headers["authorization"];
+        if (!authHeader || !authHeader.startsWith("Bearer ")) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              detail: "Authentication credentials were not provided.",
+            }),
+          );
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ results: [mockUserData] }));
+        return;
+      }
+
+      if (pathname.includes("schema") || pathname.includes("openapi")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            openapi: "3.0.0",
+            info: { title: "Mock API", version: "1.0.0" },
+            paths: {},
+          }),
+        );
+        return;
+      }
+
+      // Generic API endpoints — return mock data for tool calls
+      if (pathname.startsWith("/api/")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ count: 0, results: [] }));
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    });
+
+    server.listen(MOCK_AAP_PORT, () => resolve(server));
+  });
+};
+
+describe("End-to-End: MCP Server", () => {
+  beforeAll(async () => {
+    // Ensure aap-mcp.yaml exists (copy from sample if missing, e.g. in CI)
+    const configPath = join(process.cwd(), "aap-mcp.yaml");
+    const samplePath = join(process.cwd(), "aap-mcp.sample.yaml");
+    if (!existsSync(configPath) && existsSync(samplePath)) {
+      copyFileSync(samplePath, configPath);
+    }
+
+    // Start mock AAP server first
+    mockAapServer = await startMockAapServer();
+
+    // Set env vars BEFORE importing index.ts so it picks them up
+    process.env.BASE_URL = `http://localhost:${MOCK_AAP_PORT}`;
+    process.env.MCP_PORT = String(MCP_SERVER_PORT);
+    process.env.ANALYTICS_KEY = "test-segment-key";
+    process.env.TELEMETRY_HMAC_KEY = "test-hmac-key-for-e2e";
+    process.env.INSTALLER_ID = "e2e-test-installer-uuid";
+    process.env.INTERNAL_EMAIL_DOMAINS = "redhat.com,ibm.com,ansible.com";
+    process.env.SESSION_TIMEOUT = "30";
+    process.env.ENABLE_METRICS = "true";
+
+    // Import index.ts in-process — Vitest's V8 coverage instruments all code
+    await import("../src/index.js");
+
+    // Give the server a moment to be fully ready
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }, 30000);
+
+  afterAll(async () => {
+    if (mockAapServer) {
+      await new Promise<void>((resolve) => {
+        mockAapServer.close(() => resolve());
+      });
+    }
+  }, 10000);
+
+  // --- Health & Metrics ---
+
+  describe("Health and Metrics", () => {
+    it("should return healthy status", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/api/v1/health`);
+      expect(response.ok).toBe(true);
+
+      const data: any = await response.json();
+      expect(data.status).toBe("ok");
+    });
+
+    it("should return metrics when enabled", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/metrics`);
+      expect(response.ok).toBe(true);
+
+      const text = await response.text();
+      expect(text).toContain("mcp_");
+    });
+  });
+
+  // --- GET handler ---
+
+  describe("GET handler", () => {
+    it("should reject GET requests on /mcp", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp`);
+      expect(response.status).toBe(405);
+    });
+
+    it("should return 404 for GET on /mcp/toolset without session", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp/job_management`);
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for GET with invalid session ID", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp/job_management`, {
+        headers: { "mcp-session-id": "non-existent-session" },
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // --- POST handler - invalid requests ---
+
+  describe("POST handler - invalid requests", () => {
+    it("should return 404 for POST with non-existent session ID", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "mcp-session-id": "non-existent-session",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/list",
+          id: 1,
+        }),
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("should return error for POST without session ID and non-init request", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/list",
+          id: 1,
+        }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // --- DELETE handler ---
+
+  describe("DELETE handler", () => {
+    it("should return 404 for DELETE without session", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for DELETE with invalid session ID", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp`, {
+        method: "DELETE",
+        headers: { "mcp-session-id": "non-existent-session" },
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("should return 404 for toolset-specific DELETE without session", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/mcp/job_management`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // --- MCP Protocol Flow ---
+
+  describe("MCP Protocol - full flow", () => {
+    it("should connect, list tools, call a tool, and disconnect", async () => {
+      const { client, transport } = createMcpClient(
+        "job_management",
+        BEARER_TOKEN,
+      );
+
+      // Connect — exercises validateToken, extractBearerToken, storeSessionData
+      await client.connect(transport);
+
+      // List tools — exercises ListToolsRequestSchema handler
+      const toolsResponse = await client.listTools();
+      expect(toolsResponse.tools).toBeDefined();
+      expect(Array.isArray(toolsResponse.tools)).toBe(true);
+
+      // Call a tool — exercises CallToolRequestSchema handler
+      if (toolsResponse.tools.length > 0) {
+        const toolsWithNoParams = toolsResponse.tools.filter(
+          (t) => !t.inputSchema.required || t.inputSchema.required.length === 0,
+        );
+
+        if (toolsWithNoParams.length > 0) {
+          const tool = toolsWithNoParams[0];
+          const result = await client.callTool({ name: tool.name });
+          expect(result).toBeDefined();
+          expect(result.content).toBeDefined();
+        }
+      }
+
+      // Disconnect — exercises cleanup
+      await client.close();
+      await transport.close();
+    }, 15000);
+
+    it("should reject requests without authentication", async () => {
+      const { client, transport } = createMcpClient("job_management");
+
+      await expect(client.connect(transport)).rejects.toThrow();
+    }, 10000);
+
+    it("should connect via /mcp (all toolsets)", async () => {
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`${MCP_BASE_URL}/mcp`),
+        {
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${BEARER_TOKEN}`,
+              "User-Agent": "E2E-Test-Client/1.0",
+              "mcp-protocol-version": "2025-06-18",
+            },
+          },
+        },
+      );
+
+      const client = new Client(
+        { name: "e2e-all-toolsets", version: "1.0.0" },
+        {
+          capabilities: { tools: {} },
+          protocolVersion: "2025-06-18",
+        },
+      );
+
+      await client.connect(transport);
+
+      const toolsResponse = await client.listTools();
+      expect(toolsResponse.tools).toBeDefined();
+
+      await client.close();
+      await transport.close();
+    }, 15000);
+
+    it("should handle multiple concurrent sessions", async () => {
+      const { client: client1, transport: transport1 } = createMcpClient(
+        "job_management",
+        BEARER_TOKEN,
+      );
+      const { client: client2, transport: transport2 } = createMcpClient(
+        "job_management",
+        BEARER_TOKEN,
+      );
+
+      await client1.connect(transport1);
+      await client2.connect(transport2);
+
+      const [tools1, tools2] = await Promise.all([
+        client1.listTools(),
+        client2.listTools(),
+      ]);
+
+      expect(tools1.tools).toBeDefined();
+      expect(tools2.tools).toBeDefined();
+
+      await Promise.all([
+        client1.close().then(() => transport1.close()),
+        client2.close().then(() => transport2.close()),
+      ]);
+    }, 15000);
+  });
+
+  // --- Toolset-specific routes ---
+
+  describe("Toolset-specific routes", () => {
+    it("should connect via /:toolset/mcp path format", async () => {
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`${MCP_BASE_URL}/job_management/mcp`),
+        {
+          requestInit: {
+            headers: {
+              Authorization: `Bearer ${BEARER_TOKEN}`,
+              "User-Agent": "E2E-Test-Client/1.0",
+              "mcp-protocol-version": "2025-06-18",
+            },
+          },
+        },
+      );
+
+      const client = new Client(
+        { name: "e2e-alt-route", version: "1.0.0" },
+        {
+          capabilities: { tools: {} },
+          protocolVersion: "2025-06-18",
+        },
+      );
+
+      await client.connect(transport);
+
+      const toolsResponse = await client.listTools();
+      expect(toolsResponse.tools).toBeDefined();
+
+      await client.close();
+      await transport.close();
+    }, 15000);
+  });
+
+  // --- Additional route coverage ---
+
+  describe("Additional routes", () => {
+    it("should return response on root /", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/`);
+      expect(response.ok).toBe(true);
+    });
+
+    it("should reject DELETE on /mcp/:toolset with invalid session", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/job_management/mcp`, {
+        method: "DELETE",
+        headers: { "mcp-session-id": "bad-session" },
+      });
+      expect(response.status).toBe(404);
+    });
+
+    it("should reject POST on /:toolset/mcp without init request and no session", async () => {
+      const response = await fetch(`${MCP_BASE_URL}/job_management/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/list",
+          id: 1,
+        }),
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
     reporter: ["verbose", "json", "html"],
     outputFile: {
       json: "./test-results.json",
-      html: "./test-results.html",
+      html: "./test-results/index.html",
     },
   },
 


### PR DESCRIPTION
## Description

Replaces the volatile `user_unique_id` (which changed on every server restart) with three new stable, privacy-preserving telemetry fields:

- **`user_pseudo_id`**: HMAC-SHA-256 of the user's `ansible_id` from the `/api/gateway/v1/me/` endpoint. Stable across restarts. Falls back to literal `"anonymous"` when `ansible_id` is unavailable.
- **`installer_pseudo_id`**: HMAC-SHA-256 of the `INSTALLER_ID` env var (injected by the Operator or Containerized installer). Defaults to `"unknown"` when not set.
- **`user_type`**: `"internal"` or `"external"` based on email domain matching against `INTERNAL_EMAIL_DOMAINS` (defaults to `redhat.com,ibm.com,ansible.com`).

All pseudonymous identifiers use HMAC-SHA-256 with a persistent secret key (`TELEMETRY_HMAC_KEY`), making brute-force reversal infeasible. No PII is transmitted in any telemetry event.
