### PR TITLE
Cleanup the deletion of session from AAP MCP server

### DIFF
--- a/ANALYTICS_USAGE.md
+++ b/ANALYTICS_USAGE.md
@@ -19,67 +19,43 @@ analytics_key: "your-segment-write-key-here"
 
 ## Events Tracked
 
-### 1. Session Started (`mcp_session_started`)
+### 1. Tool Called (`mcp_tool_called`)
 
-Tracked when a new MCP session is established.
-
-**Fields:**
-
-- `user_agent` - Client user agent string
-- `sess_id` - Unique session identifier (UUID)
-- `mcp_tool_set` - Name of the specific MCP server instance
-- `process_id` - Unique identifier for the server instance (volatile)
-- `user_unique_id` - Generated from process_id and user access token
-
-**Example:**
-
-```json
-{
-  "event": "mcp_session_started",
-  "properties": {
-    "user_agent": "Claude Desktop/0.7.1",
-    "sess_id": "95f5b3cd-5931-4982-92d1-508f98045918",
-    "mcp_tool_set": "job-management",
-    "process_id": "65236301-c591-402b-a97b-0084c57d5179",
-    "user_unique_id": "b519f181-62f3-4eb7-bf96-6c1a1e9756e0"
-  }
-}
-```
-
-### 2. Tool Called (`mcp_tool_called`)
-
-Tracked for every tool invocation (both successful and failed).
+Tracked for every tool invocation (both successful and failed). The server operates in stateless mode, so each request is independent with no session tracking.
 
 **Fields:**
 
 - `tool_name` - Name of the MCP tool
 - `mcp_tool_set` - Name of the specific MCP server instance
 - `user_agent` - Client user agent string
-- `sess_id` - Session identifier (UUID)
 - `parameter_length` - Size in chars of the input payload
 - `http_status` - Return code of the HTTP request
 - `execution_time_ms` - Tool execution time in milliseconds
-- `user_unique_id` - Generated from process_id and user access token
+- `user_pseudo_id` - HMAC-SHA-256 pseudonymous user identifier
+- `user_type` - User type classification ("internal" | "external")
+- `installer_pseudo_id` - HMAC-SHA-256 pseudonymous installer identifier
 
 **Example:**
 
 ```json
 {
   "event": "mcp_tool_called",
+  "anonymousId": "a1b2c3d4e5f6...",
   "properties": {
     "tool_name": "launch_job_template",
     "mcp_tool_set": "job-management",
     "user_agent": "Claude Desktop/0.7.1",
-    "sess_id": "95f5b3cd-5931-4982-92d1-508f98045918",
     "parameter_length": 245,
     "http_status": 200,
     "execution_time_ms": 1500,
-    "user_unique_id": "b519f181-62f3-4eb7-bf96-6c1a1e9756e0"
+    "user_pseudo_id": "a1b2c3d4e5f6...",
+    "user_type": "external",
+    "installer_pseudo_id": "7g8h9i0j1k2l..."
   }
 }
 ```
 
-### 3. Server Status (`mcp_server_status`)
+### 2. Server Status (`mcp_server_status`)
 
 Tracked every 30 minutes to monitor server health.
 
@@ -87,7 +63,7 @@ Tracked every 30 minutes to monitor server health.
 
 - `process_id` - Unique identifier for the server instance (volatile)
 - `health_status` - Overall health status ("healthy", "degraded", "unhealthy")
-- `active_sessions` - Number of active sessions
+- `active_sessions` - Number of active sessions (in stateless mode, this represents concurrent connections)
 - `uptime_seconds` - Server uptime in seconds
 - `server_version` - Version of the MCP server
 - `container_version` - Version of the container
@@ -98,6 +74,7 @@ Tracked every 30 minutes to monitor server health.
 ```json
 {
   "event": "mcp_server_status",
+  "anonymousId": "65236301-c591-402b-a97b-0084c57d5179",
   "properties": {
     "process_id": "65236301-c591-402b-a97b-0084c57d5179",
     "health_status": "healthy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,12 +3090,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3406,9 +3406,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3510,9 +3510,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/analytics-validation-plugin.test.ts
+++ b/src/analytics-validation-plugin.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   createValidationPlugin,
-  validateSessionStartedEvent,
   validateToolCalledEvent,
   validateServerStatusEvent,
 } from "./analytics-validation-plugin.js";
@@ -20,86 +19,12 @@ describe("Analytics Validation Plugin", () => {
     mockContext.updateEvent.mockClear();
   });
 
-  describe("validateSessionStartedEvent", () => {
-    it("should validate a correct session started event", () => {
-      const validEvent = {
-        sess_id: "session-123",
-        process_id: "process-456",
-        user_pseudo_id: "user-789",
-        user_type: "internal",
-        installer_pseudo_id: "installer-abc",
-        user_agent: "TestAgent/1.0",
-        mcp_tool_set: "test-toolset",
-      };
-
-      expect(validateSessionStartedEvent(validEvent)).toBe(true);
-    });
-
-    it("should reject event with missing required fields", () => {
-      const invalidEvent = {
-        user_agent: "TestAgent/1.0",
-        // Missing sess_id, process_id, user_pseudo_id, user_type
-      };
-
-      expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
-    });
-
-    it("should reject event with invalid field types", () => {
-      const invalidEvent = {
-        sess_id: 123, // Should be string
-        process_id: "process-456",
-        user_pseudo_id: "user-789",
-        user_type: "internal",
-        installer_pseudo_id: "installer-abc",
-      };
-
-      expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
-    });
-
-    it("should accept event with optional fields", () => {
-      const validEvent = {
-        sess_id: "session-123",
-        process_id: "process-456",
-        user_pseudo_id: "user-789",
-        user_type: "external",
-        installer_pseudo_id: "installer-abc",
-      };
-
-      expect(validateSessionStartedEvent(validEvent)).toBe(true);
-    });
-
-    it("should reject event with unexpected fields", () => {
-      const invalidEvent = {
-        sess_id: "session-123",
-        process_id: "process-456",
-        user_pseudo_id: "user-789",
-        user_type: "internal",
-        installer_pseudo_id: "installer-abc",
-        unexpected_field: "value",
-      };
-
-      expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
-    });
-
-    it("should reject event with invalid user_type value", () => {
-      const invalidEvent = {
-        sess_id: "session-123",
-        process_id: "process-456",
-        user_pseudo_id: "user-789",
-        user_type: "admin", // Invalid value
-      };
-
-      expect(validateSessionStartedEvent(invalidEvent)).toBe(false);
-    });
-  });
-
   describe("validateToolCalledEvent", () => {
     it("should validate a correct tool called event", () => {
       const validEvent = {
         tool_name: "test-tool",
         mcp_tool_set: "test-toolset",
         user_agent: "TestAgent/1.0",
-        sess_id: "session-123",
         parameter_length: 100,
         http_status: 200,
         execution_time_ms: 500,
@@ -125,7 +50,6 @@ describe("Analytics Validation Plugin", () => {
         tool_name: "test-tool",
         mcp_tool_set: "test-toolset",
         user_agent: "TestAgent/1.0",
-        sess_id: "session-123",
         parameter_length: 100,
         http_status: 99, // Invalid HTTP status
         execution_time_ms: 500,
@@ -142,7 +66,6 @@ describe("Analytics Validation Plugin", () => {
         tool_name: "test-tool",
         mcp_tool_set: "test-toolset",
         user_agent: "TestAgent/1.0",
-        sess_id: "session-123",
         parameter_length: -10, // Invalid negative value
         http_status: 200,
         execution_time_ms: 500,
@@ -159,7 +82,6 @@ describe("Analytics Validation Plugin", () => {
         tool_name: "test-tool",
         mcp_tool_set: "test-toolset",
         user_agent: "TestAgent/1.0",
-        sess_id: "session-123",
         parameter_length: 100,
         http_status: 200,
         execution_time_ms: -100, // Invalid negative value
@@ -176,7 +98,6 @@ describe("Analytics Validation Plugin", () => {
         tool_name: "test-tool",
         mcp_tool_set: "test-toolset",
         user_agent: "TestAgent/1.0",
-        sess_id: "session-123",
         parameter_length: 0,
         http_status: 599, // Valid edge case
         execution_time_ms: 0,
@@ -299,10 +220,14 @@ describe("Analytics Validation Plugin", () => {
         const validContext = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: {
-              sess_id: "session-123",
-              process_id: "process-456",
+              tool_name: "test-tool",
+              mcp_tool_set: "test-toolset",
+              user_agent: "TestAgent/1.0",
+              parameter_length: 100,
+              http_status: 200,
+              execution_time_ms: 500,
               user_pseudo_id: "user-789",
               user_type: "internal",
               installer_pseudo_id: "installer-abc",
@@ -326,7 +251,7 @@ describe("Analytics Validation Plugin", () => {
         const invalidContext = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: {
               // Missing required fields
             },
@@ -352,7 +277,7 @@ describe("Analytics Validation Plugin", () => {
         const invalidContext = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: {
               // Missing required fields
             },
@@ -374,10 +299,14 @@ describe("Analytics Validation Plugin", () => {
         const eventWithExtraFields = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: {
-              sess_id: "session-123",
-              process_id: "process-456",
+              tool_name: "test-tool",
+              mcp_tool_set: "test-toolset",
+              user_agent: "TestAgent/1.0",
+              parameter_length: 100,
+              http_status: 200,
+              execution_time_ms: 500,
               user_pseudo_id: "user-789",
               user_type: "internal",
               installer_pseudo_id: "installer-abc",
@@ -427,10 +356,14 @@ describe("Analytics Validation Plugin", () => {
         const validContext = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: {
-              sess_id: "session-123",
-              process_id: "process-456",
+              tool_name: "test-tool",
+              mcp_tool_set: "test-toolset",
+              user_agent: "TestAgent/1.0",
+              parameter_length: 100,
+              http_status: 200,
+              execution_time_ms: 500,
               user_pseudo_id: "user-789",
               user_type: "external",
               installer_pseudo_id: "installer-abc",
@@ -507,7 +440,6 @@ describe("Analytics Validation Plugin", () => {
               tool_name: "", // Invalid empty string
               mcp_tool_set: "test-toolset",
               user_agent: "TestAgent/1.0",
-              sess_id: "session-123",
               parameter_length: "not-a-number", // Invalid type
               http_status: 200,
               execution_time_ms: 500,
@@ -597,7 +529,7 @@ describe("Analytics Validation Plugin", () => {
         const nullPropsContext = {
           ...mockContext,
           event: {
-            event: "mcp_session_started",
+            event: "mcp_tool_called",
             properties: null,
           },
         };
@@ -608,7 +540,7 @@ describe("Analytics Validation Plugin", () => {
           expect.stringContaining("Invalid event structure"),
           expect.objectContaining({
             event: expect.objectContaining({
-              event: "mcp_session_started",
+              event: "mcp_tool_called",
               properties: null,
             }),
           }),
@@ -686,7 +618,6 @@ describe("Analytics Validation Plugin", () => {
               tool_name: "test-tool",
               mcp_tool_set: "test-toolset",
               user_agent: "TestAgent/1.0",
-              sess_id: "session-123",
               parameter_length: 100,
               http_status: status,
               execution_time_ms: 500,
@@ -716,7 +647,6 @@ describe("Analytics Validation Plugin", () => {
               tool_name: "test-tool",
               mcp_tool_set: "test-toolset",
               user_agent: "TestAgent/1.0",
-              sess_id: "session-123",
               parameter_length: 100,
               http_status: status,
               execution_time_ms: 500,
@@ -749,7 +679,6 @@ describe("Analytics Validation Plugin", () => {
             tool_name: "test-tool",
             mcp_tool_set: "test-toolset",
             user_agent: "TestAgent/1.0",
-            sess_id: "session-123",
             parameter_length: 0, // Zero should be valid
             http_status: 200,
             execution_time_ms: 0, // Zero should be valid
@@ -778,7 +707,6 @@ describe("Analytics Validation Plugin", () => {
             tool_name: "", // Invalid
             mcp_tool_set: "", // Invalid
             user_agent: "", // Invalid
-            sess_id: "", // Invalid
             parameter_length: -1, // Invalid
             http_status: 99, // Invalid
             execution_time_ms: -1, // Invalid
@@ -799,7 +727,6 @@ describe("Analytics Validation Plugin", () => {
             expect.objectContaining({ field: "tool_name" }),
             expect.objectContaining({ field: "mcp_tool_set" }),
             expect.objectContaining({ field: "user_agent" }),
-            expect.objectContaining({ field: "sess_id" }),
             expect.objectContaining({ field: "parameter_length" }),
             expect.objectContaining({ field: "http_status" }),
             expect.objectContaining({ field: "execution_time_ms" }),
@@ -811,9 +738,9 @@ describe("Analytics Validation Plugin", () => {
         }),
       );
 
-      // Should have detected 11 errors
+      // Should have detected 10 errors
       const logCall = mockLogger.mock.calls[0][1];
-      expect(logCall.errors).toHaveLength(11);
+      expect(logCall.errors).toHaveLength(10);
     });
   });
 });

--- a/src/analytics-validation-plugin.ts
+++ b/src/analytics-validation-plugin.ts
@@ -1,44 +1,15 @@
 import type { Plugin, Context } from "@segment/analytics-node";
-import {
-  SessionStartedEvent,
-  ToolCalledEvent,
-  ServerStatusEvent,
-} from "./analytics.js";
+import { ToolCalledEvent, ServerStatusEvent } from "./analytics.js";
 
 /**
  * Validation schemas for different event types
  */
 const EVENT_SCHEMAS = {
-  mcp_session_started: {
-    required: [
-      "sess_id",
-      "process_id",
-      "user_pseudo_id",
-      "user_type",
-      "installer_pseudo_id",
-    ],
-    optional: ["user_agent", "mcp_tool_set"],
-    validators: {
-      sess_id: (value: any) => typeof value === "string" && value.length > 0,
-      process_id: (value: any) => typeof value === "string" && value.length > 0,
-      user_pseudo_id: (value: any) =>
-        typeof value === "string" && value.length > 0,
-      user_type: (value: any) =>
-        typeof value === "string" && ["internal", "external"].includes(value),
-      user_agent: (value: any) =>
-        value === undefined || typeof value === "string",
-      mcp_tool_set: (value: any) =>
-        value === undefined || typeof value === "string",
-      installer_pseudo_id: (value: any) =>
-        typeof value === "string" && value.length > 0,
-    },
-  },
   mcp_tool_called: {
     required: [
       "tool_name",
       "mcp_tool_set",
       "user_agent",
-      "sess_id",
       "parameter_length",
       "http_status",
       "execution_time_ms",
@@ -52,7 +23,6 @@ const EVENT_SCHEMAS = {
       mcp_tool_set: (value: any) =>
         typeof value === "string" && value.length > 0,
       user_agent: (value: any) => typeof value === "string" && value.length > 0,
-      sess_id: (value: any) => typeof value === "string" && value.length > 0,
       parameter_length: (value: any) => typeof value === "number" && value >= 0,
       http_status: (value: any) =>
         typeof value === "number" &&
@@ -280,13 +250,6 @@ export function createValidationPlugin(
 /**
  * Type-safe event validation functions for external use
  */
-export const validateSessionStartedEvent = (
-  properties: any,
-): properties is SessionStartedEvent => {
-  const errors = validateEvent("mcp_session_started", properties);
-  return errors.length === 0;
-};
-
 export const validateToolCalledEvent = (
   properties: any,
 ): properties is ToolCalledEvent => {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -236,21 +236,10 @@ export class AnalyticsService {
   }
 }
 
-export interface SessionStartedEvent {
-  user_agent?: string;
-  sess_id: string;
-  mcp_tool_set?: string;
-  process_id: string;
-  user_pseudo_id: string;
-  user_type: string;
-  installer_pseudo_id: string;
-}
-
 export interface ToolCalledEvent {
   tool_name: string;
   mcp_tool_set: string;
   user_agent: string;
-  sess_id: string;
   parameter_length: number;
   http_status: number;
   execution_time_ms: number;

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -82,7 +82,6 @@ describe("MetricsService", () => {
   });
 
   it("should record telemetry sent events", () => {
-    metricsService.recordTelemetrySent("mcp_session_started");
     metricsService.recordTelemetrySent("mcp_tool_called");
     metricsService.recordTelemetrySent("mcp_server_status");
 
@@ -99,9 +98,9 @@ describe("MetricsService", () => {
 
   it("should handle multiple telemetry events with different event types", () => {
     // Record successful telemetry
-    metricsService.recordTelemetrySent("mcp_session_started");
     metricsService.recordTelemetrySent("mcp_tool_called");
     metricsService.recordTelemetrySent("mcp_tool_called");
+    metricsService.recordTelemetrySent("mcp_server_status");
 
     // Record telemetry errors
     metricsService.recordTelemetryError();


### PR DESCRIPTION
Assisted-by: Claude

JIRA Ticket: [AAP-74882](https://redhat.atlassian.net/browse/AAP-74882)

## Description

With #143, MCP server became stateless. However, still the validation logic for `mcp_tool_called` event expected to have the `sess_id`, the validation failed and it caused an ATF test failure.  This PR is for clean up the validation code and some other codes that are related to the session ID, which no longer exist.

## Summary of changes (provided by Claude):

### 🐛 Fixed the Original Bug
- Removed `sess_id` from `mcp_tool_called` validation schema
- This was causing all analytics events to be dropped, preventing Prometheus metrics from updating

### 🧹 Cleaned Up Session-Related Code
- Removed `SessionStartedEvent` interface from analytics.ts
- Removed `mcp_session_started` validation schema from `analytics-validation-plugin.ts`
- Removed `validateSessionStartedEvent()` function
- Removed 6 test cases for session events
- Updated remaining tests to use `mcp_tool_called` instead

### 📚 Updated Documentation
- Removed the entire `mcp_session_started` event section
- Updated `mcp_tool_called` to show the new fields (`user_pseudo_id`, `user_type`, `installer_pseudo_id`)
- Removed obsolete `sess_id` field
- Added clarification about stateless mode
- Added anonymousId to example JSON snippets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup to align analytics telemetry validation and docs with stateless operation; primary impact is on whether telemetry events are accepted/dropped. Includes minor dependency bumps (`express-rate-limit`, `hono`) with limited surface area.
> 
> **Overview**
> Aligns analytics telemetry with the server’s stateless mode by **removing session tracking**: drops the `mcp_session_started` event schema/API and removes `sess_id` from the `mcp_tool_called` contract and validation.
> 
> Updates tests and metrics assertions to reflect the new event shape (tool calls + server status only), and refreshes `ANALYTICS_USAGE.md` examples/fields (including `anonymousId`). Also bumps a few npm dependencies (notably `express-rate-limit` and `hono`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a844e58972e5c0e7399f5f4f980eac02ff6cf7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->