### PR TITLE
AAP-74333: Bump fast-uri to 3.1.2 (CVE-2026-6321)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,9 +3133,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "express-rate-limit": ">=8.2.2"
+    "express-rate-limit": ">=8.2.2",
+    "fast-uri": ">=3.1.1"
   },
   "devDependencies": {
     "@endorhq/cli": "^0.2.0",


### PR DESCRIPTION
## Summary

Bumps `fast-uri` from 3.1.0 to 3.1.2 to address CVE-2026-6321.

**CVE-2026-6321** — fast-uri ≤ 3.1.0 incorrectly handles percent-encoded path separators and dot segments in `normalize()` and `equal()`, allowing an attacker to bypass path-based security policies via a crafted URI. Fixed in 3.1.1.

**Exposure:** `fast-uri` is a runtime dependency pulled in by `@modelcontextprotocol/sdk`, `@apidevtools/swagger-parser`, `@readme/openapi-parser`, and `ajv-formats`. The MCP SDK validates MCP protocol messages containing URIs at runtime using ajv, making this an exploitable path under adversarial input.

**Change:** Added `"fast-uri": ">=3.1.1"` to `overrides` in `package.json`; surgically patched `package-lock.json` to resolve to 3.1.2.

Fixes: AAP-74333

Made with [Cursor](https://cursor.com)