### PR TITLE
[POC] Implement OAuth2 Integration

### DIFF
--- a/docs/oauth2-integration.md
+++ b/docs/oauth2-integration.md
@@ -1,0 +1,489 @@
+# AAP MCP Server - OAuth 2.1 Integration
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Auth Flow](#auth-flow)
+- [Dual Auth Behavior](#dual-auth-behavior)
+- [Token Refresh Strategy](#token-refresh-strategy)
+- [OAuth 2.1 Compliance](#oauth-21-compliance)
+- [AAP Authentication Federation](#aap-authentication-federation)
+- [Environment Variables](#environment-variables)
+- [Endpoints](#endpoints)
+- [Auth Server Registration](#auth-server-registration)
+- [Design Decisions](#design-decisions)
+- [Files Changed](#files-changed)
+- [Deployment](#deployment)
+- [Compatibility](#compatibility)
+
+---
+
+## Overview
+
+The AAP MCP Server supports OAuth 2.1 Authorization Code flow with PKCE as an **opt-in** authentication method alongside the existing legacy Bearer token flow. When enabled, MCP clients (Claude Code, Cursor, Gemini CLI, and others) are automatically redirected to the AAP authorization server's login page when no token is present.
+
+The server supports two OAuth2 modes:
+
+- **Proxy mode** (`OAUTH2_DIRECT_GATEWAY=false`, default): The MCP server acts as an OAuth2 proxy — it handles client registration locally, intermediates redirect URIs, and proxies `/authorize`, `/token`, and `/revoke` to the AAP gateway. Enabled when `OAUTH2_CLIENT_ID` is set. If `OAUTH2_CLIENT_SECRET` is also set, the server operates as a confidential client; otherwise as a public client (PKCE only).
+- **Direct-gateway mode** (`OAUTH2_DIRECT_GATEWAY=true`): The MCP server only serves Protected Resource Metadata (PRM) and delegates all OAuth2 operations (AS metadata discovery, client registration, authorization, token exchange) directly to the AAP gateway. No OAuth2 endpoints are served on the MCP server. Requires the gateway to implement RFC 8414 (AS metadata), RFC 7591 (Dynamic Client Registration), and RFC 9728 (PRM).
+
+When neither `OAUTH2_CLIENT_ID` nor `OAUTH2_DIRECT_GATEWAY` is set, the server works exactly as before (legacy Bearer token only).
+
+---
+
+## Architecture
+
+### Proxy Mode
+
+```mermaid
+graph LR
+    Client["MCP Client<br/>(Claude Code, Cursor, Gemini CLI)"]
+    Server["MCP Server<br/>(OAuth2 Proxy)"]
+    AAP["AAP Gateway<br/>(Authorization Server)"]
+
+    Client -->|"1. OAuth 2.1 flow<br/>(register, authorize, token, revoke)"| Server
+    Server -->|"2. Proxy to upstream<br/>(authorize, token, revoke)"| AAP
+    Server -->|"3. Forward auth code<br/>(via /oauth/callback)"| Client
+    Client -->|"4. Bearer token<br/>(POST /mcp)"| Server
+    Server -->|"5. Validate token<br/>(JWT via JWKS or legacy /me/)"| AAP
+```
+
+The MCP server acts as an **OAuth2 proxy** between MCP clients and the AAP authorization server. It does not issue tokens itself — it proxies the authorization and token exchange to AAP, while handling client registration and redirect URI intermediation locally.
+
+### Direct-Gateway Mode
+
+```mermaid
+graph LR
+    Client["MCP Client<br/>(Claude Code, Cursor)"]
+    Server["MCP Server<br/>(PRM only)"]
+    AAP["AAP Gateway<br/>(Authorization Server)"]
+
+    Client -->|"1. POST /mcp (no token)"| Server
+    Server -->|"2. 401 + PRM URL"| Client
+    Client -->|"3. GET PRM"| Server
+    Server -->|"4. { authorization_servers: [gateway] }"| Client
+    Client -->|"5. AS metadata, register,<br/>authorize, token"| AAP
+    Client -->|"6. Bearer token<br/>(POST /mcp)"| Server
+    Server -->|"7. Validate token<br/>(legacy /me/)"| AAP
+```
+
+The MCP server only serves **Protected Resource Metadata** (RFC 9728) pointing clients to the gateway. All OAuth2 operations happen directly between the client and the gateway. The MCP server does not proxy any OAuth2 endpoints.
+
+### Key Components
+
+- **`src/oauth2-provider.ts`** — Core OAuth2 module: `createOAuth2Provider()` for proxy mode (OIDC discovery, JWKS verification, `AAPProxyOAuthServerProvider` with client registration, redirect URI intermediary, callback forwarding, and dynamic protected resource metadata) and `createDirectGatewaySetup()` for direct-gateway mode (PRM-only router with OIDC discovery for startup validation).
+- **`src/index.ts`** — Integration point: conditional initialization (proxy vs direct-gateway), OAuth2 router forwarding slot, dual-auth middleware (`authenticateRequestWithOAuth2`), and `WWW-Authenticate` headers.
+
+---
+
+## Auth Flow
+
+### Proxy Mode
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Server as MCP Server
+    participant Auth as AAP Auth Server<br/>(BASE_URL/o/)
+
+    Client->>Server: POST /mcp (no token)
+    Server-->>Client: 401 + WWW-Authenticate<br/>(resource_metadata = path-specific PRM URL)
+
+    Client->>Server: GET /.well-known/oauth-protected-resource/mcp
+    Server-->>Client: { resource: ".../mcp", authorization_servers: [...] }
+
+    Client->>Server: GET /.well-known/oauth-authorization-server
+    Server-->>Client: { authorize, token, register endpoints }
+
+    Client->>Server: POST /register
+    Note over Server: Stores client's redirect_uris,<br/>returns pre-registered credentials
+    Server-->>Client: { client_id, client_secret? }<br/>(secret only if confidential client)
+
+    Client->>Server: GET /authorize (redirect_uri=localhost:PORT/callback)
+    Note over Server: Stores client's redirect_uri,<br/>replaces with /oauth/callback
+    Server->>Auth: Redirect to authorization endpoint<br/>(redirect_uri=/oauth/callback)
+
+    Note over Auth: User authenticates
+
+    Auth->>Server: Redirect to /oauth/callback (code + state)
+    Server->>Client: Redirect to client's original callback (code + state)
+
+    Client->>Server: POST /token (code + code_verifier)
+    Server->>Auth: POST token endpoint
+    Auth-->>Server: { access_token, refresh_token }
+    Server-->>Client: { access_token, refresh_token }
+
+    Client->>Server: POST /mcp (Bearer token)
+    Note over Server: Token validated (JWT via JWKS<br/>or legacy via /api/gateway/v1/me/)
+    Server-->>Client: MCP response
+```
+
+### Direct-Gateway Mode
+
+In direct-gateway mode, the auth flow is simpler — the MCP server only participates in steps 1–4 (returning 401 and serving PRM). All OAuth2 operations (AS metadata discovery, client registration, authorization, token exchange) happen directly between the MCP client and the AAP gateway. The MCP server is not involved in those steps.
+
+### Failed Login
+
+When a user enters wrong credentials, the AAP login page stays open and lets the user retry indefinitely — this is standard behavior controlled by the upstream auth server, not by the MCP server. There is no cancel button on the AAP login page.
+
+If the user takes longer than **10 minutes** on the login page (e.g., repeated failed attempts or abandoning the page), the MCP server's pending authorization entry expires and is evicted. If the user eventually logs in successfully after the 10-minute window, the callback returns `"unknown authorization state"` and the user must restart the OAuth flow from the MCP client.
+
+> **Note:** MCP clients may enforce their own login timeout independently of the server's 10-minute pending authorization TTL. For example, a client might cancel the OAuth flow after 2–5 minutes of inactivity. The effective timeout is whichever expires first — the client's or the server's.
+
+---
+
+## Dual Auth Behavior
+
+The server supports two authentication methods simultaneously:
+
+```mermaid
+flowchart TD
+    A[Incoming Request] --> B{Has Authorization<br/>or X-Authorization header?}
+    B -->|No| C{OAuth2 enabled?}
+    C -->|Yes| D[401 + WWW-Authenticate<br/>with resource_metadata URL]
+    C -->|No| E[401 Bearer token required]
+    B -->|Yes| F{Token looks like JWT?<br/>three dot-separated segments}
+    F -->|Yes| G[Verify JWT via JWKS<br/>local, fast]
+    F -->|No| H["Legacy: validate against<br/>/api/gateway/v1/me/"]
+    G -->|Valid| I[Authenticated - proceed]
+    G -->|"Claim/signature failure<br/>(aud, iss, exp, sig)"| J[401 Invalid or expired token]
+    G -->|"Structural failure<br/>(not actually a JWT)"| H
+    H -->|Valid| I
+    H -->|Invalid| J
+```
+
+| Scenario                                             | Behavior                                                                                                                                                       |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Request with `Authorization` header, token is JWT    | JWT verification via JWKS (local, fast, validates `iss` and `aud`). Claim/signature failures reject immediately; only structural failures fall back to legacy. |
+| Request with `Authorization` header, token is opaque | Skips JWT verification, validates directly against `/api/gateway/v1/me/`                                                                                       |
+| No `Authorization` header, OAuth 2.1 enabled         | Returns 401 with `WWW-Authenticate` header to trigger OAuth 2.1 flow                                                                                           |
+| Invalid/expired token, OAuth 2.1 enabled             | Returns 401 with `WWW-Authenticate: Bearer error="invalid_token"` so clients refresh via `/token` (RFC 6750)                                                   |
+| No `Authorization` header, OAuth 2.1 disabled        | Returns 401 as before (legacy behavior)                                                                                                                        |
+
+**JWT format detection**: Tokens are only verified as JWTs if they have three dot-separated segments (`header.payload.signature`). This avoids unnecessary JWKS verification attempts and false error logs when legacy opaque tokens are used.
+
+**JWT fallback policy**: When JWT verification fails, the server distinguishes between security-relevant failures and structural failures. Audience mismatch, issuer mismatch, signature verification failure, and token expiration are **rejected immediately** without falling back to legacy validation — this prevents bypassing audience checks. Only structural errors (e.g., a token that has three dot-separated segments but is not actually a valid JWT) fall back to legacy `/me/` validation.
+
+**Header support**: The server accepts tokens via both `Authorization` and `X-Authorization` headers. The `X-Authorization` header is useful when a reverse proxy or gateway strips the standard `Authorization` header.
+
+---
+
+## Token Refresh Strategy
+
+Token refresh is the **MCP client's responsibility**. The MCP server proxies refresh requests to the upstream AAP auth server transparently.
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Server as MCP Server
+    participant Auth as AAP Auth Server
+
+    Client->>Server: POST /mcp (Bearer token)
+    Server-->>Client: 401 (token expired)
+
+    Client->>Server: POST /token<br/>(grant_type=refresh_token,<br/>refresh_token=...)
+    Server->>Auth: POST /o/token/<br/>(grant_type=refresh_token)
+    Auth-->>Server: { access_token, refresh_token }
+    Server-->>Client: { access_token, refresh_token }
+
+    Client->>Server: POST /mcp (new Bearer token)
+    Server-->>Client: MCP response
+```
+
+- The MCP SDK's `ProxyOAuthServerProvider` handles the `refresh_token` grant type automatically.
+- All tested MCP clients (Claude Code, Cursor, Gemini) implement token refresh on their side.
+- **Refresh token rotation** (issuing a new refresh token on each use) is controlled by the AAP auth server, not the MCP server.
+- No additional configuration or code is needed on the MCP server side.
+
+---
+
+## OAuth 2.1 Compliance
+
+### Compliant (MCP Server Side)
+
+| Requirement                              | Status    | Details                                                 |
+| ---------------------------------------- | --------- | ------------------------------------------------------- |
+| Authorization Code flow                  | Compliant | Only supported grant type (via proxy)                   |
+| PKCE                                     | Compliant | Handled by MCP SDK's `ProxyOAuthServerProvider`         |
+| No implicit grant                        | Compliant | Not supported by the MCP SDK or our implementation      |
+| No resource owner password grant         | Compliant | Not supported by the MCP SDK or our implementation      |
+| Exact-match redirect URI validation      | Compliant | SDK validates against registered URIs                   |
+| Confidential client                      | Compliant | `client_secret_post` authentication                     |
+| Token revocation (RFC 7009)              | Compliant | Proxied to upstream via `/revoke` endpoint              |
+| Protected resource metadata (RFC 9728)   | Compliant | Path-specific dynamic metadata                          |
+| Authorization server metadata (RFC 8414) | Compliant | Via `mcpAuthRouter`                                     |
+| Client registration (RFC 7591)           | Compliant | Local registration returning pre-registered credentials |
+
+### Upstream-Dependent
+
+| Requirement              | Responsibility  | Notes                                                                                                                   |
+| ------------------------ | --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Refresh token rotation   | AAP auth server | OAuth 2.1 recommends rotating refresh tokens on each use                                                                |
+| Refresh token expiration | AAP auth server | Must have a defined lifetime                                                                                            |
+| Token format             | AAP auth server | Currently issues opaque tokens (valid per OAuth 2.1). If changed to JWT, JWKS verification path activates automatically |
+
+### OIDC Endpoints Not Proxied
+
+AAP's `/.well-known/openid-configuration` advertises additional OpenID Connect endpoints that the MCP server does not proxy. These are **not required for OAuth 2.1 compliance**:
+
+| Endpoint               | Spec                         | Why Not Proxied                                                                                                                                                           |
+| ---------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `userinfo_endpoint`    | OpenID Connect Core 1.0      | User identity is already obtained from JWT claims (`sub`, `email`, `preferred_username`) or legacy `/api/gateway/v1/me/` validation. A userinfo proxy would be redundant. |
+| `end_session_endpoint` | OIDC RP-Initiated Logout 1.0 | MCP clients do not implement a logout flow. Tokens expire naturally. Can be added in the future if needed.                                                                |
+
+The MCP server is an **OAuth2 proxy**, not a full OIDC provider. These endpoints remain accessible directly on the AAP auth server for other consumers that need them.
+
+### Security Considerations
+
+- **JWT audience validation**: Access tokens are verified with `audience: "ansible-services"` to prevent confused deputy attacks where a JWT issued for a different application on the same IdP could be accepted.
+- **Redirect URI host allowlist**: The `/register` endpoint only accepts `redirect_uri` hostnames listed in `OAUTH2_ALLOWED_REDIRECT_HOSTS` (defaults to `localhost,127.0.0.1,[::1]`). This prevents open-redirect attacks where an attacker registers an external URI to steal authorization codes. Cloud deployments should set this to their expected MCP client hostnames.
+- **Unauthenticated `/register`**: The `/register` endpoint returns pre-registered credentials without authentication. This is required by the MCP protocol — clients have no token yet when they call `/register`. Security relies on the upstream auth server enforcing redirect URI validation: only the pre-registered `/oauth/callback` URI is accepted.
+- **OIDC discovery timeout**: The OIDC configuration fetch at startup has a 10-second timeout to prevent the server from hanging indefinitely if the upstream auth server is unreachable.
+- **OIDC metadata origin validation**: Discovered endpoint URLs (`authorization_endpoint`, `token_endpoint`, `jwks_uri`, `revocation_endpoint`) are validated against the expected `BASE_URL` origin at startup. This prevents a compromised or misconfigured OIDC discovery response from redirecting auth flows to a malicious server.
+- **WWW-Authenticate on all 401s**: When OAuth 2.1 is enabled, all 401 responses include the `WWW-Authenticate` header with `resource_metadata` and `scope`. The `scope` parameter reflects the server's write mode: `"read"` when `ALLOW_WRITE_OPERATIONS=false`, `"read write"` when enabled. This follows RFC 6750 Section 3 and helps MCP clients request only the scopes needed. Missing tokens get `Bearer resource_metadata="...", scope="..."` to trigger the OAuth 2.1 flow. Expired/invalid tokens get `Bearer error="invalid_token", resource_metadata="...", scope="..."` (RFC 6750) so clients refresh via `/token` instead of restarting the full OAuth flow.
+- **Rate limiting**: OAuth2 endpoints (`/register`, `/authorize`, `/token`, `/revoke`, `/oauth/callback`, `/.well-known/oauth*`) are rate-limited to 100 requests per minute per IP by default (configurable via `OAUTH2_RATE_LIMIT`). The default is set at 100 to accommodate environments where multiple developers share a NAT gateway. MCP data endpoints (`/mcp`) are not rate-limited.
+- **Sanitized error logging**: Request paths in error logs are sanitized to prevent log injection attacks. Error responses return a generic message instead of leaking internal details.
+- Pending authorization state entries (mapping OAuth `state` to client redirect URIs) expire after 10 minutes and are automatically evicted to prevent memory buildup.
+- Dynamic protected resource metadata responses include `Cache-Control: no-store` to prevent caching of security-sensitive metadata.
+
+---
+
+## AAP Authentication Federation
+
+### Does the MCP Server Need to Change for Federated Auth?
+
+**No.** The MCP server always authenticates against AAP gateway, regardless of whether AAP delegates user authentication to a third-party identity provider (Keycloak, Azure AD, Okta, etc.).
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Server as MCP Server
+    participant AAP as AAP Gateway<br/>(/o/authorize)
+    participant IdP as Third-party IdP<br/>(Keycloak, Azure AD, etc.)
+
+    Client->>Server: GET /authorize
+    Server->>AAP: Redirect to AAP authorization endpoint
+    AAP->>IdP: Redirect to third-party login page
+
+    Note over IdP: User authenticates<br/>with third-party IdP
+
+    IdP->>AAP: Redirect back with identity assertion
+    Note over AAP: AAP issues its own token
+    AAP->>Server: Redirect to /oauth/callback (code + state)
+    Server->>Client: Redirect to client callback (code + state)
+
+    Client->>Server: POST /token (code exchange)
+    Server->>AAP: POST /o/token/
+    AAP-->>Server: { access_token (AAP-issued) }
+    Server-->>Client: { access_token }
+```
+
+### Why It's Transparent
+
+- The MCP server talks to AAP's OIDC endpoints, not the third-party IdP's.
+- AAP's federation with the IdP is invisible to us — AAP handles the redirect to the IdP and back.
+- The token we receive is an AAP token, validated against AAP's `/api/gateway/v1/me/`.
+- A Keycloak or Azure AD token would not be accepted by AAP APIs — only AAP-issued tokens work.
+
+### OAuth Application Registration
+
+Even in a federated scenario, the OAuth application (client_id / client_secret) is **registered on AAP gateway**, not the third-party IdP. AAP is the authorization server that issues tokens for AAP resources.
+
+### The One Scenario That Would Affect Us
+
+If AAP were reconfigured to **pass through** the third-party IdP's JWT tokens instead of issuing its own opaque tokens, our JWT/JWKS verification path would become active. In that case, the JWKS verification would need to validate against the IdP's signing keys. However, the OIDC discovery at `BASE_URL/o/.well-known/openid-configuration` would reflect the new `jwks_uri` automatically — **no code changes needed**.
+
+---
+
+## Environment Variables
+
+| Variable                                    | Required             | Default                        | Description                                                                                                                                                                                                                       |
+| ------------------------------------------- | -------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OAUTH2_CLIENT_ID`                          | For proxy mode       | -                              | Pre-registered client ID on AAP auth server (proxy mode only)                                                                                                                                                                     |
+| `OAUTH2_CLIENT_SECRET`                      | Optional             | -                              | Client secret (proxy mode). If omitted, operates as a public client (PKCE only). If provided, operates as a confidential client (`client_secret_post`).                                                                           |
+| `OAUTH2_DIRECT_GATEWAY`                     | Optional             | `false`                        | Set to `true` for direct-gateway mode. The MCP server only serves PRM; clients handle OAuth2 directly with the gateway. Mutually exclusive with proxy mode.                                                                       |
+| `OAUTH2_AUTHORIZATION_SERVER`               | Optional             | `BASE_URL`                     | Authorization server URL advertised in PRM (direct-gateway mode). Include the path if the auth server uses one (e.g., `https://gateway.example.com/o`). OIDC discovery appends `/.well-known/openid-configuration` to this value. |
+| `MCP_SERVER_URL`                            | Recommended          | `http://localhost:${MCP_PORT}` | Server's public URL (used as issuer URL in proxy mode, and as PRM `resource` field in both modes)                                                                                                                                 |
+| `OAUTH2_ALLOWED_REDIRECT_HOSTS`             | Optional             | `localhost,127.0.0.1,[::1]`    | Comma-separated list of hostnames allowed in client `redirect_uri` during registration (proxy mode only). See [Compatibility](#compatibility) for known client hosts.                                                             |
+| `OAUTH2_RATE_LIMIT`                         | Optional             | `100`                          | Maximum OAuth2 requests per minute per IP. Applies to `/register`, `/authorize`, `/token`, `/revoke`, `/oauth/callback`, and `/.well-known/oauth*`.                                                                               |
+| `MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL` | For HTTP deployments | `false`                        | Set to `true` to allow non-HTTPS issuer URLs. **Must be set as a shell env var, not in `.env`** (the SDK reads it at module import time). Proxy mode only.                                                                        |
+
+---
+
+## Endpoints
+
+### Proxy Mode Endpoints
+
+| Method   | Path                                           | Description                                                                                                                                                                                   |
+| -------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET      | `/.well-known/oauth-protected-resource`        | Root protected resource metadata ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728))                                                                                                         |
+| GET      | `/.well-known/oauth-protected-resource/{path}` | Path-specific protected resource metadata                                                                                                                                                     |
+| GET      | `/.well-known/oauth-authorization-server`      | OAuth2 server metadata ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414))                                                                                                                   |
+| GET/POST | `/authorize`                                   | Proxies to upstream auth server's authorization page                                                                                                                                          |
+| POST     | `/token`                                       | Proxies authorization code / refresh token exchange                                                                                                                                           |
+| POST     | `/register`                                    | Local client registration ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)) - returns pre-registered credentials                                                                           |
+| POST     | `/revoke`                                      | Proxies token revocation to upstream auth server ([RFC 7009](https://www.rfc-editor.org/rfc/rfc7009)). Falls back to `BASE_URL/o/revoke_token/` if OIDC metadata omits `revocation_endpoint`. |
+| GET      | `/oauth/callback`                              | Receives auth code from upstream, forwards to MCP client                                                                                                                                      |
+
+### Direct-Gateway Mode Endpoints
+
+| Method | Path                                           | Description                                                                           |
+| ------ | ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| GET    | `/.well-known/oauth-protected-resource`        | Root protected resource metadata ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)) |
+| GET    | `/.well-known/oauth-protected-resource/{path}` | Path-specific protected resource metadata                                             |
+
+No OAuth2 action endpoints (`/authorize`, `/token`, `/register`, `/revoke`, `/oauth/callback`) are served in direct-gateway mode. Clients discover and use the gateway's endpoints directly via the `authorization_servers` URL in the PRM response.
+
+---
+
+## Auth Server Registration
+
+On your AAP authorization server, register the MCP server as an OAuth application. The client type depends on your deployment choice:
+
+**Confidential client** (default when `OAUTH2_CLIENT_SECRET` is set):
+
+| Setting                        | Value                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| **Client type**                | Confidential                                                                                      |
+| **Redirect URI**               | `http://localhost:3044/oauth/callback` (local) or `${MCP_SERVER_URL}/oauth/callback` (production) |
+| **Grant types**                | `authorization_code`, `refresh_token`                                                             |
+| **Token endpoint auth method** | `client_secret_post`                                                                              |
+
+**Public client** (when only `OAUTH2_CLIENT_ID` is set, no secret):
+
+| Setting                        | Value                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| **Client type**                | Public                                                                                            |
+| **Redirect URI**               | `http://localhost:3044/oauth/callback` (local) or `${MCP_SERVER_URL}/oauth/callback` (production) |
+| **Grant types**                | `authorization_code`, `refresh_token`                                                             |
+| **Token endpoint auth method** | `none` (PKCE only)                                                                                |
+
+---
+
+## Design Decisions
+
+1. **Two operating modes**: The server supports proxy mode (MCP server handles OAuth2 endpoints) and direct-gateway mode (gateway handles everything). Proxy mode is the default because it works with self-signed certs (common in dev), handles redirect URI intermediation for dynamic localhost ports, and provides local client registration. Direct-gateway mode is simpler architecturally (MCP server only serves PRM) but requires the gateway to implement RFC 7591, RFC 8414, and a valid TLS certificate that clients trust.
+2. **Proxy architecture**: OAuth 2.1 is implemented in the MCP server as a proxy to AAP gateway, not directly in the gateway. AAP gateway is already an OAuth 2.0 authorization server, but it does not implement the [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) extensions: Protected Resource Metadata (RFC 9728), Authorization Server Metadata (RFC 8414) at root-level `/.well-known` paths, Dynamic Client Registration (RFC 7591), and dynamic `localhost:PORT` redirect URI handling. Implementing these in gateway would require modifying core auth code that affects all AAP consumers (Web UI, CLI, API integrations), coupling MCP protocol evolution to gateway releases, and reconciling the MCP SDK's HTTP router with Django's request lifecycle. The proxy approach is less complex (leverages the MCP SDK's built-in auth components), faster to iterate on (independent release cycle), and keeps the blast radius small (a bug only affects MCP clients, not all of AAP authentication).
+3. **Additive**: Existing Bearer token flow is unchanged. OAuth 2.1 is opt-in via environment variables.
+4. **Intermediary callback**: The MCP server uses its own `/oauth/callback` as `redirect_uri` with the upstream auth server, then forwards the authorization code to the MCP client's dynamic localhost callback. This avoids needing to register dynamic ports on the auth server.
+5. **Local client registration**: MCP clients require [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) dynamic client registration. The `/register` endpoint accepts registration requests but always returns the pre-registered client credentials.
+6. **Dynamic protected resource metadata**: Each MCP endpoint path gets its own `/.well-known/oauth-protected-resource/{path}` response with the correct `resource` field, as required by clients that strict-match the resource URL ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)).
+7. **Route ordering**: OAuth2 router is mounted before MCP routes via a forwarding slot to ensure `/register`, `/authorize`, `/token`, and `/.well-known/*` are matched first.
+8. **JWT format detection**: Tokens are only verified as JWTs if they have three dot-separated segments, avoiding false error logs when legacy opaque tokens are used.
+9. **JWT audience validation**: Access tokens are verified with `audience: "ansible-services"` to prevent confused deputy attacks across applications sharing the same IdP.
+10. **Redirect URI host allowlist**: Client redirect URIs are validated against a configurable allowlist (`OAUTH2_ALLOWED_REDIRECT_HOSTS`), defaulting to localhost/loopback for local development.
+11. **Pending authorization TTL**: Stored redirect URIs expire after 10 minutes with automatic eviction to prevent memory leaks.
+12. **Revocation endpoint fallback**: AAP's OIDC metadata does not currently advertise `revocation_endpoint`. The server falls back to the known `BASE_URL/o/revoke_token/` endpoint. Once the upstream metadata is fixed, the discovered endpoint will be used automatically.
+13. **OIDC discovery timeout**: 10-second timeout on the OIDC configuration fetch to prevent startup hangs.
+14. **OIDC metadata origin validation**: Endpoint URLs from OIDC discovery are validated against the expected `BASE_URL` origin to prevent redirection to a malicious server.
+15. **Rate limiting**: OAuth2 endpoints are rate-limited (100 req/min per IP by default, configurable via `OAUTH2_RATE_LIMIT`) to prevent brute-force and abuse. The default accommodates environments where multiple developers share a NAT gateway. MCP data endpoints (`/mcp`) are excluded.
+16. **Sanitized error logging**: Request paths are sanitized before logging to prevent log injection. Error responses return generic messages.
+17. **JWT fallback policy**: JWT verification failures due to audience, issuer, or signature mismatch are rejected immediately without falling back to legacy `/me/` validation. Only structural failures (token is not actually a JWT) trigger fallback. This prevents bypassing audience validation via the legacy path.
+18. **In-memory pending authorization state**: The mapping from OAuth `state` to client redirect URIs is stored in-memory. This means: (a) multi-instance deployments require sticky sessions or a shared store to avoid losing state mid-flow, and (b) a server restart during an active OAuth flow causes the callback to return "unknown authorization state" — the user must restart the OAuth flow from the MCP client. This is acceptable for single-instance deployments; a shared store (e.g., Redis) can be added if horizontal scaling is needed.
+19. **Public and confidential client support**: The client type is determined by configuration. If only `OAUTH2_CLIENT_ID` is set, the server operates as a **public client** (`token_endpoint_auth_method: "none"`) — PKCE alone protects the token exchange, and no `client_secret` is returned via `/register`. If both `OAUTH2_CLIENT_ID` and `OAUTH2_CLIENT_SECRET` are set, the server operates as a **confidential client** (`client_secret_post`) — PKCE + client secret for defense in depth. This makes the client type an operator/deployment decision. AAP supports both client types (vscode-ansible uses public, for example). The MCP authorization specification requires authorization servers to support both public and confidential clients.
+20. **X-Forwarded-For on OAuth2 proxy calls**: The OAuth2 proxy injects the MCP client's original IP address as `X-Forwarded-For` on outbound requests to AAP's auth server (`/token`, `/revoke`). This is implemented via a custom `fetch` passed to the SDK's `ProxyOAuthServerProvider` and `AsyncLocalStorage` to carry the client IP through async operations. When the MCP server sits behind a load balancer or gateway, the first IP in an existing `X-Forwarded-For` chain is used. This ensures AAP can audit which client initiated the OAuth2 flow. The `/authorize` call does not need `X-Forwarded-For` because it is a browser redirect — the user's browser navigates directly to AAP's authorization endpoint, so AAP already sees the user's real IP. Only the server-to-server calls (`/token`, `/revoke`) need it, as those are `fetch` calls made by the proxy where AAP would otherwise see the proxy's IP. **Note:** `X-Forwarded-For` is **not** added to tool execution calls (`POST /mcp` → AAP API) or legacy token validation (`/api/gateway/v1/me/`). Those are general proxy concerns outside the scope of OAuth2 and should be addressed separately in a dedicated RFE or issue.
+
+---
+
+## Files Changed
+
+### `src/oauth2-provider.ts` (new)
+
+- **Proxy mode** (`createOAuth2Provider`):
+  - OIDC discovery from `${BASE_URL}/o/.well-known/openid-configuration` (10-second timeout)
+  - JWT verification via JWKS (`jose` library) with `audience: "ansible-services"` validation
+  - `AAPProxyOAuthServerProvider`: extends `ProxyOAuthServerProvider` with local client registration, `redirect_uri` intermediary, redirect URI host allowlist, and authorization code forwarding
+  - Pending authorization TTL (10 min) with automatic eviction
+  - Dynamic protected resource metadata handler with `Cache-Control: no-store`
+  - Custom `fetch` with `AsyncLocalStorage` to inject `X-Forwarded-For` on outbound OAuth2 proxy calls
+  - `mcpAuthRouter` configuration
+- **Direct-gateway mode** (`createDirectGatewaySetup`):
+  - OIDC discovery from `${OAUTH2_AUTHORIZATION_SERVER}/.well-known/openid-configuration` for startup validation
+  - PRM-only router (root and path-specific) advertising the configured authorization server URL
+  - No OAuth2 action endpoints — clients interact with the gateway directly
+
+### `src/index.ts` (modified)
+
+- Config entries: `OAUTH2_CLIENT_ID`, `OAUTH2_CLIENT_SECRET`, `OAUTH2_DIRECT_GATEWAY`, `OAUTH2_AUTHORIZATION_SERVER`, `MCP_SERVER_URL`, `OAUTH2_ALLOWED_REDIRECT_HOSTS`
+- OAuth2 router forwarding slot with rate limiting (before MCP routes)
+- Conditional OAuth2 initialization in `main()`
+- Path-specific `WWW-Authenticate` headers in early auth middleware
+- `authenticateRequestWithOAuth2()`: JWT-first dual auth with format detection
+- Sanitized error handler for OAuth2 router errors
+- Startup banner shows OAuth2 status
+
+---
+
+## Deployment
+
+### Local Development
+
+#### AAP OAuth Application Setup
+
+Create an OAuth Application in AAP with the following settings:
+
+| Setting                      | Value                                  |
+| ---------------------------- | -------------------------------------- |
+| **Name**                     | MCP-Server                             |
+| **Organization**             | Default                                |
+| **Authorization Grant Type** | Authorization code                     |
+| **Client Type**              | Confidential                           |
+| **Algorithm**                | No OIDC support                        |
+| **Skip Authorization**       | Yes                                    |
+| **Redirect URIs**            | `http://localhost:3044/oauth/callback` |
+
+After creation, AAP provides the `client_id` and `client_secret` to use below.
+
+#### MCP Server Environment (Proxy Mode)
+
+```bash
+# .env
+OAUTH2_CLIENT_ID=your-client-id
+OAUTH2_CLIENT_SECRET=your-client-secret
+MCP_SERVER_URL=http://localhost:3044
+OAUTH2_ALLOWED_REDIRECT_HOSTS=www.cursor.com,anysphere.cursor-mcp,localhost,127.0.0.1,[::1]
+```
+
+#### MCP Server Environment (Direct-Gateway Mode)
+
+```bash
+# .env
+OAUTH2_DIRECT_GATEWAY=true
+OAUTH2_AUTHORIZATION_SERVER=https://your-gateway.example.com/o
+MCP_SERVER_URL=http://localhost:3044
+```
+
+> **TLS Note:** In direct-gateway mode, MCP clients connect directly to the gateway for OAuth2 operations. If the gateway uses a self-signed or internal CA certificate, clients will reject it. On macOS, use `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` when launching Node.js-based MCP clients (Claude Code, Cursor). For local dev with self-signed certs, proxy mode is recommended — it absorbs the TLS problem via `IGNORE_CERTIFICATE_ERRORS`.
+
+### Cloud / Production
+
+```bash
+# Shell environment (not .env) — only if using HTTP
+export MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL=true
+
+# .env or environment
+OAUTH2_CLIENT_ID=your-client-id
+OAUTH2_CLIENT_SECRET=your-client-secret
+MCP_SERVER_URL=https://mcp.example.com
+OAUTH2_ALLOWED_REDIRECT_HOSTS=myapp.example.com,other.example.com
+```
+
+Register `https://mcp.example.com/oauth/callback` as the redirect URI on your AAP auth server.
+
+---
+
+## Compatibility
+
+| Client              | Proxy Mode                           | Direct-Gateway Mode                                                                                                                                                                                                                                                                                      | Redirect URI Hosts                       |
+| ------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Claude Code         | Working                              | Working                                                                                                                                                                                                                                                                                                  | `localhost`                              |
+| Cursor              | Working                              | Working                                                                                                                                                                                                                                                                                                  | `www.cursor.com`, `anysphere.cursor-mcp` |
+| Gemini CLI          | Working (requires path-specific PRM) | Not working — known bugs ([#20990](https://github.com/google-gemini/gemini-cli/issues/20990), [#17603](https://github.com/google-gemini/gemini-cli/issues/17603), [#17604](https://github.com/google-gemini/gemini-cli/issues/17604)): `registrationUrl` is discovered but dropped during the OAuth flow | `localhost`                              |
+| Legacy Bearer token | Unchanged behavior                   | Unchanged behavior                                                                                                                                                                                                                                                                                       | N/A                                      |
+
+**Note**: Clients that use non-localhost redirect hosts (e.g., Cursor) require those hosts to be added to `OAUTH2_ALLOWED_REDIRECT_HOSTS` (proxy mode only). Example for Cursor:
+
+```bash
+OAUTH2_ALLOWED_REDIRECT_HOSTS=www.cursor.com,anysphere.cursor-mcp,localhost,127.0.0.1,[::1]
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "@segment/analytics-node": "^2.3.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
+        "jose": "^6.2.3",
         "js-yaml": "^4.1.0",
         "oas-normalize": "^15.0.2",
         "openapi-types": "^12.1.3",
@@ -32,7 +35,7 @@
         "@typescript-eslint/parser": "^8.56.1",
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.18",
-        "concurrently": "^9.2.1",
+        "concurrently": "^10.0.3",
         "esbuild": "^0.28.0",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
@@ -2285,33 +2288,16 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cliui": {
@@ -2357,28 +2343,156 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
+      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "4.1.2",
+        "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "shell-quote": "1.8.4",
+        "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
+        "yargs": "18.0.0"
       },
       "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/content-disposition": {
@@ -3198,6 +3312,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4756,9 +4883,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4976,16 +5103,13 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -36,13 +36,15 @@
     "@segment/analytics-node": "^2.3.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
+    "jose": "^6.2.3",
     "js-yaml": "^4.1.0",
     "oas-normalize": "^15.0.2",
     "openapi-types": "^12.1.3",
     "prom-client": "^15.1.3"
   },
   "overrides": {
-    "express-rate-limit": ">=8.2.2",
     "fast-uri": ">=3.1.1"
   },
   "devDependencies": {
@@ -56,7 +58,7 @@
     "@typescript-eslint/parser": "^8.56.1",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
-    "concurrently": "^9.2.1",
+    "concurrently": "^10.0.3",
     "esbuild": "^0.28.0",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,13 @@ import {
 import { AnalyticsService } from "./analytics.js";
 import { PseudoIdentityService, type UserInfo } from "./pseudo-identity.js";
 import { AapMcpConfig, loadToolsetsFromCfg } from "./config-utils.js";
+import {
+  createOAuth2Provider,
+  createDirectGatewaySetup,
+  type OAuth2Setup,
+} from "./oauth2-provider.js";
+import { errors as joseErrors } from "jose";
+import rateLimit from "express-rate-limit";
 
 // Load environment variables
 config();
@@ -51,7 +58,31 @@ const CONFIG = {
     localConfig.analytics_key ||
     ""
   ).trim(),
+  OAUTH2_CLIENT_ID: (process.env.OAUTH2_CLIENT_ID || "").trim(),
+  OAUTH2_CLIENT_SECRET: (process.env.OAUTH2_CLIENT_SECRET || "").trim(),
+  MCP_SERVER_URL: (process.env.MCP_SERVER_URL || "").trim(),
+  OAUTH2_ALLOWED_REDIRECT_HOSTS: (
+    process.env.OAUTH2_ALLOWED_REDIRECT_HOSTS || "localhost,127.0.0.1,[::1]"
+  )
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean),
+  OAUTH2_RATE_LIMIT: process.env.OAUTH2_RATE_LIMIT
+    ? parseInt(process.env.OAUTH2_RATE_LIMIT, 10)
+    : 100,
+  OAUTH2_DIRECT_GATEWAY:
+    (process.env.OAUTH2_DIRECT_GATEWAY || "").trim().toLowerCase() === "true",
+  OAUTH2_AUTHORIZATION_SERVER: (
+    process.env.OAUTH2_AUTHORIZATION_SERVER || ""
+  ).trim(),
 } as const;
+
+const oauth2Enabled = !!CONFIG.OAUTH2_CLIENT_ID || CONFIG.OAUTH2_DIRECT_GATEWAY;
+const oauth2ClientType = CONFIG.OAUTH2_CLIENT_SECRET
+  ? "confidential"
+  : "public";
+const oauth2Mode = CONFIG.OAUTH2_DIRECT_GATEWAY ? "direct-gateway" : "proxy";
+let oauth2Setup: OAuth2Setup | undefined;
 
 // Initialize analytics service (always instantiated, but only enabled if key provided)
 const analyticsService = new AnalyticsService();
@@ -83,6 +114,8 @@ const allowWriteOperations = getBooleanConfig(
 const allowedOperations = allowWriteOperations
   ? ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
   : ["GET", "HEAD", "OPTIONS"];
+
+const oauth2Scope = allowWriteOperations ? "read write" : "read";
 
 // Get configured default page size
 const { value: defaultPageSize, source: defaultPageSizeSource } =
@@ -124,6 +157,29 @@ const extractBearerToken = (
   return authHeader && authHeader.startsWith("Bearer ")
     ? authHeader.substring(7)
     : undefined;
+};
+
+const extractTokenFromRequest = (req: express.Request): string | undefined => {
+  const authHeader = (req.headers["authorization"] ||
+    req.headers["x-authorization"]) as string;
+  return extractBearerToken(authHeader);
+};
+
+const buildRequestContext = (
+  token: string,
+  toolset: string,
+  userInfo: UserInfo,
+  userAgent: string,
+): RequestContext => {
+  const identity = userIdentityService.deriveIdentity(userInfo);
+  return {
+    token,
+    toolset,
+    userAgent,
+    userPseudoId: identity.userPseudoId,
+    userType: identity.userType,
+    installerPseudoId: identity.installerPseudoId,
+  };
 };
 
 // Validate authorization token
@@ -435,14 +491,38 @@ app.use((req, res, next) => {
     // Reject requests without session ID or Authorization header immediately
     // This prevents expensive JSON parsing and session creation for unauthenticated requests
     if (!sessionId && !authHeader) {
-      res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Unauthorized: Bearer token or session ID required",
-        },
-        id: null,
-      });
+      console.log(
+        `${getTimestamp()} POST ${req.path} — no auth header, returning 401 (mode: ${oauth2Mode})`,
+      );
+      if (oauth2Setup) {
+        const metadataUrl = oauth2Setup.getResourceMetadataUrl(req.path);
+        console.log(
+          `${getTimestamp()} WWW-Authenticate → resource_metadata="${metadataUrl}"`,
+        );
+        res
+          .status(401)
+          .set(
+            "WWW-Authenticate",
+            `Bearer resource_metadata="${metadataUrl}", scope="${oauth2Scope}"`,
+          )
+          .json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message: "Unauthorized: Bearer token required",
+            },
+            id: null,
+          });
+      } else {
+        res.status(401).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Unauthorized: Bearer token or session ID required",
+          },
+          id: null,
+        });
+      }
       return;
     }
   }
@@ -458,7 +538,7 @@ app.use(
   }),
 );
 
-// Authenticate the request and build the per-request context
+// Authenticate via legacy token validation against AAP /me/
 const authenticateRequest = async (
   req: express.Request,
   toolset: string,
@@ -467,9 +547,7 @@ const authenticateRequest = async (
   | { ok: false; reason: "no-token" }
   | { ok: false; reason: "invalid-token" }
 > => {
-  const authHeader = (req.headers["authorization"] ||
-    req.headers["x-authorization"]) as string;
-  const token = extractBearerToken(authHeader);
+  const token = extractTokenFromRequest(req);
   if (!token) {
     return { ok: false, reason: "no-token" };
   }
@@ -482,20 +560,75 @@ const authenticateRequest = async (
     return { ok: false, reason: "invalid-token" };
   }
 
-  const identity = userIdentityService.deriveIdentity(userInfo);
   const userAgent = (req.headers["user-agent"] as string) || "unknown";
-
   return {
     ok: true,
-    ctx: {
-      token,
-      toolset,
-      userAgent,
-      userPseudoId: identity.userPseudoId,
-      userType: identity.userType,
-      installerPseudoId: identity.installerPseudoId,
-    },
+    ctx: buildRequestContext(token, toolset, userInfo, userAgent),
   };
+};
+
+// Try to authenticate via JWT (OAuth2) first, then fall back to legacy token validation
+const authenticateRequestWithOAuth2 = async (
+  req: express.Request,
+  toolset: string,
+): Promise<
+  | { ok: true; ctx: RequestContext }
+  | { ok: false; reason: "no-token" }
+  | { ok: false; reason: "invalid-token" }
+> => {
+  const token = extractTokenFromRequest(req);
+  if (!token) {
+    console.log(
+      `${getTimestamp()} POST ${req.path} — no Bearer token found in request`,
+    );
+    return { ok: false, reason: "no-token" };
+  }
+
+  // Try JWT verification first (fast, local) when OAuth2 is configured
+  // Only attempt if the token looks like a JWT (three dot-separated segments)
+  if (oauth2Setup && token.split(".").length === 3) {
+    console.log(
+      `${getTimestamp()} POST ${req.path} — attempting JWT verification (mode: ${oauth2Mode})`,
+    );
+    try {
+      const authInfo = await oauth2Setup.verifyAccessToken(token);
+      const jwtExtra = authInfo.extra || {};
+      const userInfo: UserInfo = {
+        ansibleId: jwtExtra.sub as string,
+        email: jwtExtra.email as string,
+      };
+      const userAgent = (req.headers["user-agent"] as string) || "unknown";
+      console.log(
+        `${getTimestamp()} POST ${req.path} — JWT auth successful (sub: ${jwtExtra.sub})`,
+      );
+      return {
+        ok: true,
+        ctx: buildRequestContext(token, toolset, userInfo, userAgent),
+      };
+    } catch (jwtError) {
+      // Audience, issuer, or signature failures are security-relevant —
+      // reject immediately without falling back to legacy validation.
+      if (
+        jwtError instanceof joseErrors.JWTClaimValidationFailed ||
+        jwtError instanceof joseErrors.JWTExpired ||
+        jwtError instanceof joseErrors.JWSSignatureVerificationFailed
+      ) {
+        console.debug(
+          `${getTimestamp()} JWT rejected (no fallback): %s`,
+          jwtError instanceof Error ? jwtError.message : jwtError,
+        );
+        return { ok: false, reason: "invalid-token" };
+      }
+      // Structural errors (not actually a JWT) — fall back to legacy
+      console.debug(
+        `${getTimestamp()} JWT verification failed, falling back to legacy auth: %s`,
+        jwtError instanceof Error ? jwtError.message : jwtError,
+      );
+    }
+  }
+
+  // Legacy path: validate opaque token against AAP /me/
+  return authenticateRequest(req, toolset);
 };
 
 // MCP POST endpoint handler - stateless, no sessions
@@ -507,20 +640,40 @@ const mcpPostHandler = async (
   console.log(`${getTimestamp()} Received MCP request`);
 
   try {
-    // Authenticate every request
-    const authResult = await authenticateRequest(req, toolset);
+    // Authenticate every request (JWT first if OAuth2 enabled, then legacy)
+    const authResult = await authenticateRequestWithOAuth2(req, toolset);
     if (!authResult.ok) {
       const isInvalidToken = authResult.reason === "invalid-token";
-      res.status(401).json({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: isInvalidToken
-            ? "Unauthorized: Invalid or expired token"
-            : "Unauthorized: Bearer token required",
-        },
-        id: isInvalidToken ? (req.body as any)?.id || null : null,
-      });
+      if (oauth2Setup) {
+        const metadataUrl = oauth2Setup.getResourceMetadataUrl(req.path);
+        const wwwAuth = isInvalidToken
+          ? `Bearer error="invalid_token", resource_metadata="${metadataUrl}", scope="${oauth2Scope}"`
+          : `Bearer resource_metadata="${metadataUrl}", scope="${oauth2Scope}"`;
+        res
+          .status(401)
+          .set("WWW-Authenticate", wwwAuth)
+          .json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message: isInvalidToken
+                ? "Unauthorized: Invalid or expired token"
+                : "Unauthorized: Bearer token required",
+            },
+            id: isInvalidToken ? (req.body as any)?.id || null : null,
+          });
+      } else {
+        res.status(401).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: isInvalidToken
+              ? "Unauthorized: Invalid or expired token"
+              : "Unauthorized: Bearer token required",
+          },
+          id: isInvalidToken ? (req.body as any)?.id || null : null,
+        });
+      }
       return;
     }
 
@@ -565,6 +718,54 @@ const mcpPostHandler = async (
 
 const allTools: AAPMcpToolDefinition[] = await generateTools();
 const allToolsets = loadToolsetsFromCfg(allTools, localConfig);
+
+// OAuth2 auth router placeholder — mounted here (before MCP routes) so
+// /authorize, /token, /register, /.well-known/* are matched first.
+// The actual router is attached in main() after OIDC discovery completes.
+const oauthRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: CONFIG.OAUTH2_RATE_LIMIT,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later" },
+  skip: (req) =>
+    !req.path.startsWith("/.well-known/oauth") &&
+    ![
+      "/register",
+      "/authorize",
+      "/token",
+      "/revoke",
+      "/oauth/callback",
+    ].includes(req.path),
+});
+let oauthRouterSlot: express.RequestHandler | undefined;
+app.use((req, res, next) => {
+  if (oauthRouterSlot) {
+    return oauthRateLimiter(req, res, () => oauthRouterSlot!(req, res, next));
+  }
+  next();
+});
+// Catch errors from the OAuth2 router that would otherwise return a bare 500
+app.use(
+  (
+    err: Error,
+    req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    const safePath = req.path.replace(/[^\w/.-]/g, "_");
+    console.error(
+      "%s [OAuth2 error] %s %s: %s",
+      getTimestamp(),
+      req.method,
+      safePath,
+      err.message,
+    );
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  },
+);
 
 // Set up routes - POST only, no GET/DELETE (no sessions to stream or terminate)
 app.post("/mcp", (req, res) => mcpPostHandler(req, res));
@@ -620,6 +821,39 @@ if (enableMetrics) {
 }
 
 async function main(): Promise<void> {
+  // Initialize OAuth2 provider if configured
+  if (oauth2Enabled) {
+    const serverUrl =
+      CONFIG.MCP_SERVER_URL || `http://localhost:${CONFIG.MCP_PORT}`;
+    try {
+      if (CONFIG.OAUTH2_DIRECT_GATEWAY) {
+        // Direct-gateway mode: AAP is the authorization server.
+        // MCP server serves PRM + AS metadata (from gateway OIDC discovery).
+        oauth2Setup = await createDirectGatewaySetup({
+          baseUrl: CONFIG.BASE_URL,
+          serverUrl,
+          authorizationServer:
+            CONFIG.OAUTH2_AUTHORIZATION_SERVER || CONFIG.BASE_URL,
+        });
+      } else {
+        // Proxy mode: MCP server proxies OAuth2 to AAP.
+        oauth2Setup = await createOAuth2Provider({
+          clientId: CONFIG.OAUTH2_CLIENT_ID,
+          ...(CONFIG.OAUTH2_CLIENT_SECRET && {
+            clientSecret: CONFIG.OAUTH2_CLIENT_SECRET,
+          }),
+          baseUrl: CONFIG.BASE_URL,
+          serverUrl,
+          allowedRedirectHosts: CONFIG.OAUTH2_ALLOWED_REDIRECT_HOSTS,
+        });
+      }
+      oauthRouterSlot = oauth2Setup.authRouter;
+    } catch (error) {
+      console.error(`${getTimestamp()} OAuth2 initialization failed:`, error);
+      console.error(`${getTimestamp()} Falling back to legacy auth only`);
+    }
+  }
+
   // Print startup banner
   console.log("");
   console.log("═══════════════════════════════════════════════════════════");
@@ -639,6 +873,14 @@ async function main(): Promise<void> {
     `  Certificate validation: ${ignoreCertificateErrors ? "DISABLED" : "ENABLED"}`,
   );
   console.log(`  Metrics: ${enableMetrics ? "ENABLED" : "DISABLED"}`);
+  console.log(
+    `  OAuth2: ${oauth2Setup ? `ENABLED (${oauth2Mode}${oauth2Mode === "proxy" ? `, ${oauth2ClientType} client` : ""})` : "DISABLED"}`,
+  );
+  if (oauth2Setup) {
+    console.log(
+      `  OAuth2 rate limit: ${CONFIG.OAUTH2_RATE_LIMIT} req/min per IP`,
+    );
+  }
   console.log(
     `  Default page_size: ${defaultPageSize} (from ${defaultPageSizeSource})`,
   );

--- a/src/oauth2-provider.ts
+++ b/src/oauth2-provider.ts
@@ -1,0 +1,530 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import express from "express";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { ProxyOAuthServerProvider } from "@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js";
+import type { ProxyOptions } from "@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js";
+import type { AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import {
+  mcpAuthRouter,
+  getOAuthProtectedResourceMetadataUrl,
+} from "@modelcontextprotocol/sdk/server/auth/router.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { Response } from "express";
+
+// Configuration for direct-gateway mode (AAP as authorization server).
+export interface DirectGatewayConfig {
+  baseUrl: string; // AAP base URL
+  serverUrl: string; // MCP server's own public URL (used in PRM resource field)
+  authorizationServer: string; // Authorization server URL advertised in PRM (env: OAUTH2_AUTHORIZATION_SERVER, defaults to baseUrl)
+}
+
+// Carries the MCP client's IP through async operations so the custom fetch
+// can attach X-Forwarded-For on outbound requests to the upstream auth server.
+const clientIpStore = new AsyncLocalStorage<string>();
+
+// Custom fetch that injects X-Forwarded-For from the current async context.
+const forwardingFetch: typeof fetch = (input, init) => {
+  const clientIp = clientIpStore.getStore();
+  if (clientIp) {
+    const headers = new Headers(init?.headers);
+    headers.set("X-Forwarded-For", clientIp);
+    return fetch(input, { ...init, headers });
+  }
+  return fetch(input, init);
+};
+
+// Configuration required to initialize the OAuth2 provider.
+export interface OAuth2Config {
+  clientId: string;
+  clientSecret?: string; // If omitted, operates as a public client (PKCE only, no secret)
+  baseUrl: string; // AAP base URL (OIDC discovery at ${baseUrl}/o/.well-known/openid-configuration)
+  serverUrl: string; // MCP server's own public URL (used as issuer and for callback URL)
+  allowedRedirectHosts: string[]; // Hostnames allowed in client redirect_uris
+}
+
+// Returned by createOAuth2Provider() after successful OIDC discovery.
+export interface OAuth2Setup {
+  authRouter: express.RequestHandler; // Composed router: callback + PRM + mcpAuthRouter
+  verifyAccessToken: (token: string) => Promise<AuthInfo>; // JWT verification via JWKS
+  getResourceMetadataUrl: (path: string) => string; // Builds path-specific PRM URL (RFC 9728)
+}
+
+interface OIDCMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  revocation_endpoint?: string;
+}
+
+// Extends ProxyOAuthServerProvider to:
+// 1. Add local client registration (MCP clients require RFC 7591)
+// 2. Intercept the redirect_uri so the upstream auth server only sees our
+//    server's callback URL, not the MCP client's dynamic localhost port.
+class AAPProxyOAuthServerProvider extends ProxyOAuthServerProvider {
+  private _registeredRedirectUris = new Set<string>();
+  private _conf: { clientId: string; clientSecret?: string };
+  private _serverCallbackUrl: string;
+  private _allowedRedirectHosts: string[];
+  // Maps state → { redirect_uri, timestamp }. Entries expire after 10 minutes.
+  private _pendingAuthorizations = new Map<
+    string,
+    { uri: string; createdAt: number }
+  >();
+  private static readonly PENDING_AUTH_TTL_MS = 10 * 60 * 1000;
+
+  constructor(
+    options: ProxyOptions & {
+      clientId: string;
+      clientSecret?: string;
+      serverCallbackUrl: string;
+      allowedRedirectHosts: string[];
+    },
+  ) {
+    super(options);
+    this._conf = {
+      clientId: options.clientId,
+      clientSecret: options.clientSecret,
+    };
+    this._serverCallbackUrl = options.serverCallbackUrl;
+    this._allowedRedirectHosts = options.allowedRedirectHosts;
+  }
+
+  // In-memory client store providing RFC 7591 Dynamic Client Registration.
+  //
+  // Why POST /register returns credentials without authentication:
+  // The MCP protocol requires clients to call POST /register before starting
+  // the OAuth2 flow — the client has no token yet at this point. AAP does not
+  // support RFC 7591 natively, so we implement it locally. No new client is
+  // created on the upstream auth server — the same pre-registered client_id
+  // is always returned.
+  //
+  // Client type is determined by configuration:
+  // - Public (no client_secret): PKCE alone protects the token exchange.
+  // - Confidential (with client_secret): PKCE + client_secret for defense
+  //   in depth. The upstream auth server enforces redirect_uri validation,
+  //   so an attacker with the credentials cannot redirect auth codes to an
+  //   arbitrary endpoint.
+  override get clientsStore(): OAuthRegisteredClientsStore {
+    const isConfidential = !!this._conf.clientSecret;
+    const authMethod = isConfidential ? "client_secret_post" : "none";
+
+    return {
+      getClient: async (
+        clientId: string,
+      ): Promise<OAuthClientInformationFull | undefined> => {
+        if (clientId !== this._conf.clientId) {
+          return undefined;
+        }
+
+        return {
+          client_id: this._conf.clientId,
+          ...(isConfidential && { client_secret: this._conf.clientSecret }),
+          redirect_uris: [...this._registeredRedirectUris],
+          token_endpoint_auth_method: authMethod,
+        } as OAuthClientInformationFull;
+      },
+
+      registerClient: async (
+        clientMetadata: Omit<
+          OAuthClientInformationFull,
+          "client_id" | "client_id_issued_at"
+        >,
+      ): Promise<OAuthClientInformationFull> => {
+        if (clientMetadata.redirect_uris) {
+          for (const uri of clientMetadata.redirect_uris) {
+            const parsed = new URL(uri);
+            if (!this._allowedRedirectHosts.includes(parsed.hostname)) {
+              console.warn(
+                `[OAuth2] Rejected redirect_uri with host "%s" (allowed: %s)`,
+                parsed.hostname,
+                this._allowedRedirectHosts.join(", "),
+              );
+              throw new Error(
+                `Invalid redirect_uri: host "${parsed.hostname}" is not allowed. Configure OAUTH2_ALLOWED_REDIRECT_HOSTS to add it.`,
+              );
+            }
+            this._registeredRedirectUris.add(uri);
+          }
+        }
+
+        return {
+          client_id: this._conf.clientId,
+          ...(isConfidential && { client_secret: this._conf.clientSecret }),
+          client_id_issued_at: Math.floor(Date.now() / 1000),
+          redirect_uris: [...this._registeredRedirectUris],
+          token_endpoint_auth_method: authMethod,
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+        } as OAuthClientInformationFull;
+      },
+    };
+  }
+
+  override async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response,
+  ): Promise<void> {
+    // Store the MCP client's original redirect_uri keyed by state
+    if (params.state) {
+      this._evictExpiredAuthorizations();
+      this._pendingAuthorizations.set(params.state, {
+        uri: params.redirectUri,
+        createdAt: Date.now(),
+      });
+    }
+
+    // Redirect to upstream with OUR callback URL instead of the client's
+    const modifiedParams: AuthorizationParams = {
+      ...params,
+      redirectUri: this._serverCallbackUrl,
+    };
+
+    return super.authorize(client, modifiedParams, res);
+  }
+
+  override async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    codeVerifier?: string,
+    _redirectUri?: string,
+    resource?: URL,
+  ): Promise<OAuthTokens> {
+    // Send OUR callback URL to the upstream token endpoint (must match
+    // what was used in the authorize step)
+    return super.exchangeAuthorizationCode(
+      client,
+      authorizationCode,
+      codeVerifier,
+      this._serverCallbackUrl,
+      resource,
+    );
+  }
+
+  // Retrieves and removes the MCP client's original redirect_uri for a given
+  // OAuth state parameter. Returns undefined if the state is unknown or expired.
+  getOriginalRedirectUri(state: string): string | undefined {
+    const entry = this._pendingAuthorizations.get(state);
+    this._pendingAuthorizations.delete(state);
+    if (!entry) return undefined;
+    if (
+      Date.now() - entry.createdAt >
+      AAPProxyOAuthServerProvider.PENDING_AUTH_TTL_MS
+    ) {
+      return undefined;
+    }
+    return entry.uri;
+  }
+
+  // Removes expired pending authorizations to prevent memory buildup.
+  private _evictExpiredAuthorizations(): void {
+    const now = Date.now();
+    for (const [key, entry] of this._pendingAuthorizations) {
+      if (
+        now - entry.createdAt >
+        AAPProxyOAuthServerProvider.PENDING_AUTH_TTL_MS
+      ) {
+        this._pendingAuthorizations.delete(key);
+      }
+    }
+  }
+}
+
+// Initializes the OAuth2 provider by performing OIDC discovery against the
+// upstream AAP auth server, then assembles the composed Express router that
+// handles: /oauth/callback, /.well-known/oauth-protected-resource/{path},
+// and the SDK's mcpAuthRouter (/authorize, /token, /register, /revoke,
+// /.well-known/oauth-authorization-server, /.well-known/oauth-protected-resource).
+export async function createOAuth2Provider(
+  config: OAuth2Config,
+): Promise<OAuth2Setup> {
+  // Discover upstream OAuth2/OIDC endpoints
+  const oidcUrl = `${config.baseUrl}/o/.well-known/openid-configuration`;
+  const oidcResponse = await fetch(oidcUrl, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!oidcResponse.ok) {
+    throw new Error(
+      `Failed to fetch OIDC configuration from ${oidcUrl}: ${oidcResponse.status} ${oidcResponse.statusText}`,
+    );
+  }
+  const oidcMetadata = (await oidcResponse.json()) as OIDCMetadata;
+
+  // Validate that discovered endpoint URLs belong to the expected origin
+  const expectedOrigin = new URL(config.baseUrl).origin;
+  const endpointsToValidate: [string, string][] = [
+    ["authorization_endpoint", oidcMetadata.authorization_endpoint],
+    ["token_endpoint", oidcMetadata.token_endpoint],
+    ["jwks_uri", oidcMetadata.jwks_uri],
+  ];
+  if (oidcMetadata.revocation_endpoint) {
+    endpointsToValidate.push([
+      "revocation_endpoint",
+      oidcMetadata.revocation_endpoint,
+    ]);
+  }
+  for (const [name, url] of endpointsToValidate) {
+    if (new URL(url).origin !== expectedOrigin) {
+      throw new Error(
+        `OIDC metadata ${name} origin mismatch: expected ${expectedOrigin}, got ${new URL(url).origin}`,
+      );
+    }
+  }
+
+  // Build JWKS verifier for local JWT access token validation
+  const jwks = createRemoteJWKSet(new URL(oidcMetadata.jwks_uri));
+
+  const verifyAccessToken = async (token: string): Promise<AuthInfo> => {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: oidcMetadata.issuer,
+      audience: "ansible-services",
+    });
+
+    return {
+      token,
+      clientId: config.clientId,
+      scopes: payload.scope ? String(payload.scope).split(" ") : [],
+      expiresAt: payload.exp,
+      extra: {
+        sub: payload.sub,
+        email: (payload as Record<string, unknown>).email,
+        preferred_username: (payload as Record<string, unknown>)
+          .preferred_username,
+      },
+    };
+  };
+
+  // The intermediary callback URL registered on the upstream auth server.
+  // MCP clients use dynamic localhost ports that can't be pre-registered,
+  // so we intercept with our own fixed callback and forward the auth code.
+  const serverCallbackUrl = `${config.serverUrl}/oauth/callback`;
+
+  const provider = new AAPProxyOAuthServerProvider({
+    endpoints: {
+      authorizationUrl: oidcMetadata.authorization_endpoint,
+      tokenUrl: oidcMetadata.token_endpoint,
+      // AAP's OIDC metadata does not advertise revocation_endpoint;
+      // fall back to the known endpoint until the upstream bug is fixed.
+      revocationUrl:
+        oidcMetadata.revocation_endpoint || `${config.baseUrl}/o/revoke_token/`,
+    },
+    fetch: forwardingFetch,
+    verifyAccessToken,
+    getClient: async () => undefined,
+    clientId: config.clientId,
+    ...(config.clientSecret && { clientSecret: config.clientSecret }),
+    serverCallbackUrl,
+    allowedRedirectHosts: config.allowedRedirectHosts,
+  });
+
+  const serverUrl = new URL(config.serverUrl);
+
+  // SDK-provided router: mounts /authorize, /token, /register, /revoke,
+  // /.well-known/oauth-authorization-server, /.well-known/oauth-protected-resource
+  const authRouterMiddleware = mcpAuthRouter({
+    provider,
+    issuerUrl: serverUrl,
+    baseUrl: serverUrl,
+    resourceServerUrl: serverUrl,
+  });
+
+  // Callback endpoint: receives auth code from upstream, forwards to the MCP client
+  const callbackRouter = express.Router();
+  callbackRouter.get("/oauth/callback", (req, res) => {
+    const code = req.query.code as string;
+    const state = req.query.state as string;
+    const error = req.query.error as string;
+
+    if (error) {
+      const errorDesc =
+        (req.query.error_description as string) || "Authorization failed";
+      if (state) {
+        const originalUri = provider.getOriginalRedirectUri(state);
+        if (originalUri) {
+          const redirectUrl = new URL(originalUri);
+          redirectUrl.searchParams.set("error", error);
+          redirectUrl.searchParams.set("error_description", errorDesc);
+          redirectUrl.searchParams.set("state", state);
+          res.redirect(redirectUrl.toString());
+          return;
+        }
+      }
+      res.status(400).json({ error, error_description: errorDesc });
+      return;
+    }
+
+    if (!state || !code) {
+      res.status(400).json({ error: "missing state or code" });
+      return;
+    }
+
+    const originalRedirectUri = provider.getOriginalRedirectUri(state);
+    if (!originalRedirectUri) {
+      res.status(400).json({ error: "unknown authorization state" });
+      return;
+    }
+
+    // Forward the auth code to the MCP client's original callback
+    const redirectUrl = new URL(originalRedirectUri);
+    redirectUrl.searchParams.set("code", code);
+    redirectUrl.searchParams.set("state", state);
+    res.redirect(redirectUrl.toString());
+  });
+
+  // Dynamic protected resource metadata for path-specific endpoints (RFC 9728).
+  // Some MCP clients strict-match the "resource" field against the URL they
+  // connect to, so /.well-known/oauth-protected-resource/mcp must return
+  // resource: "http://host:port/mcp", and similarly for toolset endpoints.
+  const dynamicPrmRouter = express.Router();
+  dynamicPrmRouter.get(
+    "/.well-known/oauth-protected-resource/{*splat}",
+    (req, res) => {
+      const prefix = "/.well-known/oauth-protected-resource";
+      const resourcePath = req.path.slice(prefix.length) || "/";
+      const resourceUrl = new URL(resourcePath, serverUrl);
+      res.set("Cache-Control", "no-store").json({
+        resource: resourceUrl.href,
+        authorization_servers: [serverUrl.href],
+      });
+    },
+  );
+
+  // Captures the MCP client's IP into AsyncLocalStorage so forwardingFetch
+  // can attach X-Forwarded-For on outbound requests to the upstream auth server.
+  const captureClientIp: express.RequestHandler = (req, _res, next) => {
+    const forwarded = req.headers["x-forwarded-for"];
+    const clientIp =
+      typeof forwarded === "string"
+        ? forwarded.split(",")[0].trim()
+        : req.ip || "unknown";
+    clientIpStore.run(clientIp, () => next());
+  };
+
+  // Order matters: callback and dynamic PRM must be matched before the SDK
+  // router, which has its own catch-all /.well-known/oauth-protected-resource.
+  const composedRouter = express.Router();
+  composedRouter.use(captureClientIp);
+  composedRouter.use(callbackRouter);
+  composedRouter.use(dynamicPrmRouter);
+  composedRouter.use(authRouterMiddleware);
+
+  // Builds the /.well-known/oauth-protected-resource URL for a given MCP
+  // endpoint path. Used in WWW-Authenticate headers on 401 responses.
+  const getResourceMetadataUrl = (path: string): string => {
+    const resourceUrl = new URL(path, serverUrl);
+    return getOAuthProtectedResourceMetadataUrl(resourceUrl);
+  };
+
+  return {
+    authRouter: composedRouter,
+    verifyAccessToken,
+    getResourceMetadataUrl,
+  };
+}
+
+// Direct-gateway mode: AAP gateway is the authorization server. The MCP
+// server only serves Protected Resource Metadata (RFC 9728) pointing
+// clients directly to the gateway. The gateway handles everything:
+// AS metadata discovery, dynamic client registration, authorization,
+// and token exchange. Token validation uses the legacy /me/ endpoint.
+export async function createDirectGatewaySetup(
+  config: DirectGatewayConfig,
+): Promise<OAuth2Setup> {
+  const ts = () => new Date().toISOString().split(".")[0] + "Z";
+
+  const serverUrl = new URL(config.serverUrl);
+  const authorizationServerUrl = config.authorizationServer;
+
+  // Discover the gateway's OIDC metadata to validate connectivity at startup.
+  const oidcUrl = `${authorizationServerUrl}/.well-known/openid-configuration`;
+  console.log(`${ts()} [direct-gateway] Discovering OIDC at ${oidcUrl}`);
+  const oidcResponse = await fetch(oidcUrl, {
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!oidcResponse.ok) {
+    throw new Error(
+      `Failed to fetch OIDC configuration from ${oidcUrl}: ${oidcResponse.status} ${oidcResponse.statusText}`,
+    );
+  }
+  const oidcMetadata = (await oidcResponse.json()) as OIDCMetadata & {
+    registration_endpoint?: string;
+  };
+
+  console.log(`${ts()} [direct-gateway] OIDC discovery successful:`);
+  console.log(`${ts()}   issuer: ${oidcMetadata.issuer}`);
+  console.log(
+    `${ts()}   authorization_endpoint: ${oidcMetadata.authorization_endpoint}`,
+  );
+  console.log(`${ts()}   token_endpoint: ${oidcMetadata.token_endpoint}`);
+  if (oidcMetadata.registration_endpoint) {
+    console.log(
+      `${ts()}   registration_endpoint: ${oidcMetadata.registration_endpoint}`,
+    );
+  }
+
+  // Use the configured authorization server URL in PRM as-is, preserving
+  // any path component (e.g. /o) so clients discover AS metadata at the
+  // correct RFC 8414 path on the gateway.
+  const authorizationServer = authorizationServerUrl.replace(/\/+$/, "");
+
+  console.log(
+    `${ts()} [direct-gateway] Initialized — PRM authorization_servers: ${authorizationServer} (issuer: ${oidcMetadata.issuer})`,
+  );
+
+  const router = express.Router();
+
+  // PRM — root
+  router.get("/.well-known/oauth-protected-resource", (req, res) => {
+    console.log(`${ts()} [direct-gateway] PRM request (root) from ${req.ip}`);
+    const body = {
+      resource: serverUrl.href,
+      authorization_servers: [authorizationServer],
+    };
+    console.log(
+      `${ts()} [direct-gateway] PRM response: ${JSON.stringify(body)}`,
+    );
+    res.set("Cache-Control", "no-store").json(body);
+  });
+
+  // PRM — path-specific (e.g. /mcp, /toolset/mcp)
+  router.get("/.well-known/oauth-protected-resource/{*splat}", (req, res) => {
+    const prefix = "/.well-known/oauth-protected-resource";
+    const resourcePath = req.path.slice(prefix.length) || "/";
+    const resourceUrl = new URL(resourcePath, serverUrl);
+    console.log(
+      `${ts()} [direct-gateway] PRM request (path: ${resourcePath}) from ${req.ip}`,
+    );
+    const body = {
+      resource: resourceUrl.href,
+      authorization_servers: [authorizationServer],
+    };
+    console.log(
+      `${ts()} [direct-gateway] PRM response: ${JSON.stringify(body)}`,
+    );
+    res.set("Cache-Control", "no-store").json(body);
+  });
+
+  const getResourceMetadataUrl = (path: string): string => {
+    const resourceUrl = new URL(path, serverUrl);
+    return getOAuthProtectedResourceMetadataUrl(resourceUrl);
+  };
+
+  // No JWT verification — token validation falls back to legacy /me/ endpoint.
+  const verifyAccessToken = async (_token: string): Promise<AuthInfo> => {
+    throw new Error(
+      "direct-gateway: no local JWT verification, use legacy auth",
+    );
+  };
+
+  return {
+    authRouter: router,
+    verifyAccessToken,
+    getResourceMetadataUrl,
+  };
+}


### PR DESCRIPTION
Implement OAuth2 Integration

Enable opt-in OAuth2 authentication alongside the existing Bearer token
flow. When OAUTH2_CLIENT_ID and OAUTH2_CLIENT_SECRET are set, MCP
clients (Claude Code, Cursor, Gemini CLI) are automatically redirected
to the AAP authorization server's login page when no token is present.

Key features:
- OAuth2 proxy between MCP clients and AAP auth server (OIDC discovery,
  PKCE, token exchange, revocation)
- RFC 7591 local client registration returning pre-registered credentials
- RFC 9728 path-specific protected resource metadata
- Dual auth: JWT verification via JWKS with fallback to legacy /me/ validation
- JWT audience validation (ansible-services) to prevent confused deputy attacks
- Configurable redirect URI host allowlist (OAUTH2_ALLOWED_REDIRECT_HOSTS)
- OIDC metadata origin validation and 10s discovery timeout
- WWW-Authenticate headers on all 401 responses when OAuth2 is enabled
- RFC 6750 error="invalid_token" for expired tokens to trigger refresh
- Rate limiting on OAuth2 endpoints (60 req/min per IP)
- Sanitized error logging to prevent log injection

New file: src/oauth2-provider.ts
Modified: src/index.ts, package.json
Documentation: docs/oauth2-integration.md

Issue: https://redhat.atlassian.net/browse/AAP-75808
Co-Authored-By: Claude Code <noreply@anthropic.com>

Note: this is a POC but very stable code and maybe considered as a basis for implementation.

for more details see document [docs/oauth2-integration.md](https://github.com/ansible/aap-mcp-server/blob/oauth2-integration/docs/oauth2-integration.md)

Put it in draft as not intended to be merged for now