### PR TITLE
AAP-60942: feat: add configurable default page_size for list operations

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -23,6 +23,11 @@
 # Allow write operation (POST, DELETE and PATCH)
 # allow_write_operations: false
 
+# Global default page size for all list operations (1-200)
+# Priority: DEFAULT_PAGE_SIZE env var > this setting > hard-coded default (10)
+# OpenAPI schema defaults take precedence over this value
+# default-page-size: 10
+
 services:
   - name: controller
     # url: "https://custom-controller.example.com/api/v2/schema/"

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -628,6 +628,11 @@ describe("getDefaultPageSize", () => {
       expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");
     });
 
+    it("should reject env var with trailing garbage", () => {
+      process.env.DEFAULT_PAGE_SIZE = "75abc";
+      expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");
+    });
+
     it("should reject negative env var", () => {
       process.env.DEFAULT_PAGE_SIZE = "-5";
       expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { AAPMcpToolDefinition } from "./openapi-loader.js";
 import { AapMcpConfig, loadToolsetsFromCfg } from "./config-utils.js";
+import {
+  getDefaultPageSize,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from "./extract-tools.js";
 
 // Helper function to create mock tools with all required properties
 const createMockTool = (
@@ -524,6 +529,132 @@ describe("loadToolsetsFromCfg", () => {
       const allToolNames = result.all.map((tool) => tool.fullName);
       expect(allToolNames).toContain("eda.tool1");
       expect(allToolNames).toContain("controller.tool2");
+    });
+  });
+});
+
+describe("getDefaultPageSize", () => {
+  const originalEnv = process.env.DEFAULT_PAGE_SIZE;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.DEFAULT_PAGE_SIZE;
+    } else {
+      process.env.DEFAULT_PAGE_SIZE = originalEnv;
+    }
+  });
+
+  describe("priority resolution", () => {
+    it("should return hard-coded default when no config or env var is set", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      const result = getDefaultPageSize();
+      expect(result.value).toBe(DEFAULT_PAGE_SIZE);
+      expect(result.source).toBe("hard-coded default");
+    });
+
+    it("should return hard-coded default when config has no default-page-size", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      const result = getDefaultPageSize({});
+      expect(result.value).toBe(DEFAULT_PAGE_SIZE);
+      expect(result.source).toBe("hard-coded default");
+    });
+
+    it("should use config file value when set and no env var", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      const result = getDefaultPageSize({ "default-page-size": 50 });
+      expect(result.value).toBe(50);
+      expect(result.source).toBe("config file");
+    });
+
+    it("should use environment variable over config file", () => {
+      process.env.DEFAULT_PAGE_SIZE = "75";
+      const result = getDefaultPageSize({ "default-page-size": 50 });
+      expect(result.value).toBe(75);
+      expect(result.source).toBe("environment variable");
+    });
+
+    it("should use environment variable when no config provided", () => {
+      process.env.DEFAULT_PAGE_SIZE = "42";
+      const result = getDefaultPageSize();
+      expect(result.value).toBe(42);
+      expect(result.source).toBe("environment variable");
+    });
+
+    it("should ignore config file value when env var is set", () => {
+      process.env.DEFAULT_PAGE_SIZE = "100";
+      const result = getDefaultPageSize({ "default-page-size": 25 });
+      expect(result.value).toBe(100);
+      expect(result.source).toBe("environment variable");
+    });
+  });
+
+  describe("validation", () => {
+    it("should reject negative config file value", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      expect(() => getDefaultPageSize({ "default-page-size": -1 })).toThrow(
+        "Must be a positive integer",
+      );
+    });
+
+    it("should reject zero config file value", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      expect(() => getDefaultPageSize({ "default-page-size": 0 })).toThrow(
+        "Must be a positive integer",
+      );
+    });
+
+    it("should reject non-integer config file value", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      expect(() => getDefaultPageSize({ "default-page-size": 10.5 })).toThrow(
+        "Must be a positive integer",
+      );
+    });
+
+    it("should reject config file value exceeding MAX_PAGE_SIZE", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      expect(() => getDefaultPageSize({ "default-page-size": 201 })).toThrow(
+        `exceeds maximum of ${MAX_PAGE_SIZE}`,
+      );
+    });
+
+    it("should accept config file value at MAX_PAGE_SIZE", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      const result = getDefaultPageSize({ "default-page-size": MAX_PAGE_SIZE });
+      expect(result.value).toBe(MAX_PAGE_SIZE);
+    });
+
+    it("should reject non-numeric env var", () => {
+      process.env.DEFAULT_PAGE_SIZE = "abc";
+      expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");
+    });
+
+    it("should reject negative env var", () => {
+      process.env.DEFAULT_PAGE_SIZE = "-5";
+      expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");
+    });
+
+    it("should reject zero env var", () => {
+      process.env.DEFAULT_PAGE_SIZE = "0";
+      expect(() => getDefaultPageSize()).toThrow("Must be a positive integer");
+    });
+
+    it("should reject env var exceeding MAX_PAGE_SIZE", () => {
+      process.env.DEFAULT_PAGE_SIZE = "300";
+      expect(() => getDefaultPageSize()).toThrow(
+        `exceeds maximum of ${MAX_PAGE_SIZE}`,
+      );
+    });
+
+    it("should accept env var at MAX_PAGE_SIZE", () => {
+      process.env.DEFAULT_PAGE_SIZE = String(MAX_PAGE_SIZE);
+      const result = getDefaultPageSize();
+      expect(result.value).toBe(MAX_PAGE_SIZE);
+    });
+
+    it("should accept value of 1", () => {
+      delete process.env.DEFAULT_PAGE_SIZE;
+      const result = getDefaultPageSize({ "default-page-size": 1 });
+      expect(result.value).toBe(1);
     });
   });
 });

--- a/src/config-utils.test.ts
+++ b/src/config-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { AAPMcpToolDefinition } from "./openapi-loader.js";
 import { AapMcpConfig, loadToolsetsFromCfg } from "./config-utils.js";
 import {

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -7,6 +7,7 @@ export interface AapMcpConfig {
   allow_write_operations?: boolean;
   base_url?: string;
   session_timeout?: number;
+  "default-page-size"?: number;
   services?: ServiceConfig[];
   toolsets: Record<string, string[]>;
   analytics_key?: string;

--- a/src/extract-tools.test.ts
+++ b/src/extract-tools.test.ts
@@ -1009,7 +1009,7 @@ describe("Default page_size in tool extraction", () => {
   });
 
   it("should not affect tools without page_size parameter", () => {
-    const spec = {
+    const spec: any = {
       openapi: "3.0.0",
       info: { title: "Test API", version: "1.0.0" },
       paths: {
@@ -1054,7 +1054,7 @@ describe("Default page_size in tool extraction", () => {
   });
 
   it("should only apply to query parameters named page_size", () => {
-    const spec = {
+    const spec: any = {
       openapi: "3.0.0",
       info: { title: "Test API", version: "1.0.0" },
       paths: {

--- a/src/extract-tools.test.ts
+++ b/src/extract-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   extractToolsFromApi,
+  generateInputSchemaAndDetails,
   AAPOperationObject,
   normalizeBoolean,
   shouldIncludeOperationForMcp,
@@ -950,5 +951,198 @@ describe("shouldIncludeOperationForMcp", () => {
     );
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe("Default page_size in tool extraction", () => {
+  const createSpecWithPageSize = (pageSizeDefault?: number) => {
+    const pageSizeParam: any = {
+      name: "page_size",
+      in: "query",
+      schema: { type: "integer" },
+      description: "Number of results per page",
+    };
+    if (pageSizeDefault !== undefined) {
+      pageSizeParam.schema.default = pageSizeDefault;
+    }
+    return {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/items": {
+          get: {
+            operationId: "items_list",
+            "x-ai-description": "List items",
+            parameters: [pageSizeParam],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    };
+  };
+
+  it("should set page_size default when not present in OpenAPI schema", () => {
+    const spec = createSpecWithPageSize();
+    const tools = extractToolsFromApi(spec, true, 10);
+
+    expect(tools).toHaveLength(1);
+    const schema = tools[0].inputSchema as any;
+    expect(schema.properties.page_size.default).toBe(10);
+  });
+
+  it("should preserve existing OpenAPI schema default", () => {
+    const spec = createSpecWithPageSize(25);
+    const tools = extractToolsFromApi(spec, true, 10);
+
+    expect(tools).toHaveLength(1);
+    const schema = tools[0].inputSchema as any;
+    expect(schema.properties.page_size.default).toBe(25);
+  });
+
+  it("should not set default when defaultPageSize is not provided", () => {
+    const spec = createSpecWithPageSize();
+    const tools = extractToolsFromApi(spec, true);
+
+    expect(tools).toHaveLength(1);
+    const schema = tools[0].inputSchema as any;
+    expect(schema.properties.page_size.default).toBeUndefined();
+  });
+
+  it("should not affect tools without page_size parameter", () => {
+    const spec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/items/{id}": {
+          get: {
+            operationId: "items_retrieve",
+            "x-ai-description": "Retrieve item",
+            parameters: [
+              {
+                name: "id",
+                in: "path",
+                required: true,
+                schema: { type: "integer" },
+                description: "Item ID",
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    };
+
+    const tools = extractToolsFromApi(spec, true, 10);
+    expect(tools).toHaveLength(1);
+    const schema = tools[0].inputSchema as any;
+    expect(schema.properties.id).toBeDefined();
+    expect(schema.properties.page_size).toBeUndefined();
+  });
+
+  it("should apply different defaultPageSize values", () => {
+    const spec = createSpecWithPageSize();
+
+    const tools50 = extractToolsFromApi(spec, true, 50);
+    expect((tools50[0].inputSchema as any).properties.page_size.default).toBe(50);
+
+    const tools100 = extractToolsFromApi(spec, true, 100);
+    expect((tools100[0].inputSchema as any).properties.page_size.default).toBe(100);
+  });
+
+  it("should only apply to query parameters named page_size", () => {
+    const spec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/items/{page_size}": {
+          get: {
+            operationId: "items_by_page",
+            "x-ai-description": "List items by page size",
+            parameters: [
+              {
+                name: "page_size",
+                in: "path",
+                required: true,
+                schema: { type: "integer" },
+                description: "Page size in path",
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    };
+
+    const tools = extractToolsFromApi(spec, true, 10);
+    expect(tools).toHaveLength(1);
+    const schema = tools[0].inputSchema as any;
+    expect(schema.properties.page_size.default).toBeUndefined();
+  });
+});
+
+describe("generateInputSchemaAndDetails with defaultPageSize", () => {
+  it("should set page_size default on query parameter", () => {
+    const operation = new AAPOperationObject({
+      operationId: "test_list",
+      parameters: [
+        {
+          name: "page_size",
+          in: "query",
+          schema: { type: "integer" },
+          description: "Page size",
+        },
+      ],
+      responses: { "200": { description: "OK" } },
+    });
+
+    const { inputSchema } = generateInputSchemaAndDetails(
+      operation,
+      undefined,
+      15,
+    );
+
+    expect((inputSchema as any).properties.page_size.default).toBe(15);
+  });
+
+  it("should not override existing default", () => {
+    const operation = new AAPOperationObject({
+      operationId: "test_list",
+      parameters: [
+        {
+          name: "page_size",
+          in: "query",
+          schema: { type: "integer", default: 25 },
+          description: "Page size",
+        },
+      ],
+      responses: { "200": { description: "OK" } },
+    });
+
+    const { inputSchema } = generateInputSchemaAndDetails(
+      operation,
+      undefined,
+      15,
+    );
+
+    expect((inputSchema as any).properties.page_size.default).toBe(25);
+  });
+
+  it("should not set default when defaultPageSize is undefined", () => {
+    const operation = new AAPOperationObject({
+      operationId: "test_list",
+      parameters: [
+        {
+          name: "page_size",
+          in: "query",
+          schema: { type: "integer" },
+          description: "Page size",
+        },
+      ],
+      responses: { "200": { description: "OK" } },
+    });
+
+    const { inputSchema } = generateInputSchemaAndDetails(operation);
+
+    expect((inputSchema as any).properties.page_size.default).toBeUndefined();
   });
 });

--- a/src/extract-tools.test.ts
+++ b/src/extract-tools.test.ts
@@ -1043,10 +1043,14 @@ describe("Default page_size in tool extraction", () => {
     const spec = createSpecWithPageSize();
 
     const tools50 = extractToolsFromApi(spec, true, 50);
-    expect((tools50[0].inputSchema as any).properties.page_size.default).toBe(50);
+    expect((tools50[0].inputSchema as any).properties.page_size.default).toBe(
+      50,
+    );
 
     const tools100 = extractToolsFromApi(spec, true, 100);
-    expect((tools100[0].inputSchema as any).properties.page_size.default).toBe(100);
+    expect((tools100[0].inputSchema as any).properties.page_size.default).toBe(
+      100,
+    );
   });
 
   it("should only apply to query parameters named page_size", () => {

--- a/src/extract-tools.ts
+++ b/src/extract-tools.ts
@@ -19,8 +19,9 @@ export function getDefaultPageSize(config?: { "default-page-size"?: number }): {
   let source: string = "hard-coded default";
 
   if (process.env.DEFAULT_PAGE_SIZE) {
-    const envValue = Number.parseInt(process.env.DEFAULT_PAGE_SIZE, 10);
-    if (Number.isNaN(envValue) || envValue < 1) {
+    const envRaw = process.env.DEFAULT_PAGE_SIZE.trim();
+    const envValue = Number(envRaw);
+    if (!Number.isInteger(envValue) || envValue < 1) {
       throw new Error(
         `Invalid DEFAULT_PAGE_SIZE environment variable: ${process.env.DEFAULT_PAGE_SIZE}. Must be a positive integer.`,
       );

--- a/src/extract-tools.ts
+++ b/src/extract-tools.ts
@@ -19,8 +19,8 @@ export function getDefaultPageSize(config?: { "default-page-size"?: number }): {
   let source: string = "hard-coded default";
 
   if (process.env.DEFAULT_PAGE_SIZE) {
-    const envValue = parseInt(process.env.DEFAULT_PAGE_SIZE, 10);
-    if (isNaN(envValue) || envValue < 1) {
+    const envValue = Number.parseInt(process.env.DEFAULT_PAGE_SIZE, 10);
+    if (Number.isNaN(envValue) || envValue < 1) {
       throw new Error(
         `Invalid DEFAULT_PAGE_SIZE environment variable: ${process.env.DEFAULT_PAGE_SIZE}. Must be a positive integer.`,
       );

--- a/src/extract-tools.ts
+++ b/src/extract-tools.ts
@@ -8,6 +8,46 @@ import { OpenAPIV3 } from "openapi-types";
 import type { JSONSchema7 } from "json-schema";
 import type { McpToolDefinition } from "openapi-mcp-generator";
 
+export const DEFAULT_PAGE_SIZE = 10;
+export const MAX_PAGE_SIZE = 200;
+
+export function getDefaultPageSize(config?: { "default-page-size"?: number }): {
+  value: number;
+  source: string;
+} {
+  let resolvedValue: number = DEFAULT_PAGE_SIZE;
+  let source: string = "hard-coded default";
+
+  if (process.env.DEFAULT_PAGE_SIZE) {
+    const envValue = parseInt(process.env.DEFAULT_PAGE_SIZE, 10);
+    if (isNaN(envValue) || envValue < 1) {
+      throw new Error(
+        `Invalid DEFAULT_PAGE_SIZE environment variable: ${process.env.DEFAULT_PAGE_SIZE}. Must be a positive integer.`,
+      );
+    }
+    resolvedValue = envValue;
+    source = "environment variable";
+  } else if (config?.["default-page-size"] !== undefined) {
+    const configValue = config["default-page-size"];
+    if (!Number.isInteger(configValue) || configValue < 1) {
+      throw new Error(
+        `Invalid default-page-size: ${configValue}. Must be a positive integer.`,
+      );
+    }
+    resolvedValue = configValue;
+    source = "config file";
+  }
+
+  if (resolvedValue > MAX_PAGE_SIZE) {
+    throw new Error(
+      `Invalid page size ${resolvedValue} (from ${source}): exceeds maximum of ${MAX_PAGE_SIZE}. ` +
+        `Large page sizes defeat the purpose of this setting and risk exhausting the LLM context window.`,
+    );
+  }
+
+  return { value: resolvedValue, source };
+}
+
 export interface McpToolLogEntry {
   severity: "INFO" | "WARN" | "ERR";
   msg: string;
@@ -214,6 +254,7 @@ export function mapOpenApiSchemaToJsonSchema(
 export function generateInputSchemaAndDetails(
   operation: AAPOperationObject,
   pathParameters?: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[],
+  defaultPageSize?: number,
 ): {
   inputSchema: JSONSchema7 | boolean;
   parameters: OpenAPIV3.ParameterObject[];
@@ -259,6 +300,17 @@ export function generateInputSchemaAndDetails(
     const paramSchema = mapOpenApiSchemaToJsonSchema(
       param.schema as OpenAPIV3.SchemaObject,
     );
+
+    if (
+      param.name === "page_size" &&
+      param.in === "query" &&
+      typeof paramSchema === "object" &&
+      defaultPageSize !== undefined &&
+      paramSchema.default === undefined
+    ) {
+      paramSchema.default = defaultPageSize;
+    }
+
     if (typeof paramSchema === "object") {
       paramSchema.description = param.description || paramSchema.description;
     }
@@ -328,6 +380,7 @@ export function generateInputSchemaAndDetails(
 export function extractToolsFromApi(
   api: OpenAPIV3.Document,
   defaultInclude = true,
+  defaultPageSize?: number,
 ): AAPMcpToolDefinition[] {
   const tools: AAPMcpToolDefinition[] = [];
   const usedNames = new Set<string>();
@@ -431,7 +484,7 @@ export function extractToolsFromApi(
 
       // Generate input schema and extract parameters
       const { inputSchema, parameters, requestBodyContentType } =
-        generateInputSchemaAndDetails(operation, pathItem.parameters);
+        generateInputSchemaAndDetails(operation, pathItem.parameters, defaultPageSize);
 
       if (typeof inputSchema === "object" && inputSchema.properties) {
         const propertiesEntries = Object.entries(inputSchema.properties).map(

--- a/src/extract-tools.ts
+++ b/src/extract-tools.ts
@@ -484,7 +484,11 @@ export function extractToolsFromApi(
 
       // Generate input schema and extract parameters
       const { inputSchema, parameters, requestBodyContentType } =
-        generateInputSchemaAndDetails(operation, pathItem.parameters, defaultPageSize);
+        generateInputSchemaAndDetails(
+          operation,
+          pathItem.parameters,
+          defaultPageSize,
+        );
 
       if (typeof inputSchema === "object" && inputSchema.properties) {
         const propertiesEntries = Object.entries(inputSchema.properties).map(

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,9 +640,11 @@ async function main(): Promise<void> {
   console.log(
     `  Default page_size: ${defaultPageSize} (from ${defaultPageSizeSource})`,
   );
-  console.log(
-    `  NOTE: Default page_size changed to ${defaultPageSize} (was 25). Set DEFAULT_PAGE_SIZE=25 to restore previous behavior.`,
-  );
+  if (defaultPageSizeSource === "hard-coded default") {
+    console.log(
+      `  NOTE: Default page_size changed to ${defaultPageSize} (was 25). Set DEFAULT_PAGE_SIZE=25 to restore previous behavior.`,
+    );
+  }
   console.log("");
   console.log("───────────────────────────────────────────────────────────");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { extractToolsFromApi } from "./extract-tools.js";
+import { extractToolsFromApi, getDefaultPageSize } from "./extract-tools.js";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import * as yaml from "js-yaml";
@@ -83,6 +83,10 @@ const allowWriteOperations = getBooleanConfig(
 const allowedOperations = allowWriteOperations
   ? ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
   : ["GET", "HEAD", "OPTIONS"];
+
+// Get configured default page size
+const { value: defaultPageSize, source: defaultPageSizeSource } =
+  getDefaultPageSize(localConfig);
 
 // Get services configuration
 const servicesConfig = localConfig.services || [];
@@ -193,6 +197,8 @@ const generateTools = async (): Promise<AAPMcpToolDefinition[]> => {
     try {
       const tools = extractToolsFromApi(
         bundledSpec as any,
+        true,
+        defaultPageSize,
       ) as AAPMcpToolDefinition[];
       const filteredTools = tools.filter((tool) => {
         tool.service = spec.service; // Add service information to each tool
@@ -631,6 +637,12 @@ async function main(): Promise<void> {
     `  Certificate validation: ${ignoreCertificateErrors ? "DISABLED" : "ENABLED"}`,
   );
   console.log(`  Metrics: ${enableMetrics ? "ENABLED" : "DISABLED"}`);
+  console.log(
+    `  Default page_size: ${defaultPageSize} (from ${defaultPageSizeSource})`,
+  );
+  console.log(
+    `  NOTE: Default page_size changed to ${defaultPageSize} (was 25). Set DEFAULT_PAGE_SIZE=25 to restore previous behavior.`,
+  );
   console.log("");
   console.log("───────────────────────────────────────────────────────────");
 


### PR DESCRIPTION
Jira ticket: [AAP-60942](https://redhat.atlassian.net/browse/AAP-60942)

  ### Summary

  Adds a configurable global `default_page_size` setting that injects a
  `page_size` default into the JSON Schema of every list-type MCP tool.
  This lets operators control how many results the LLM fetches per page,
  reducing context-window waste from oversized responses.

  ### Motivation
  
  Without a configurable default, list operations rely on per-API schema
  defaults (often 25+), which can return more data than needed and consume
  LLM context budget. Operators need a single knob to tune this globally.

  ### Changes
  
  | File | Description |
  |------|-------------|
  | `src/extract-tools.ts` | Add `getDefaultPageSize()` resolver with three-tier priority: `DEFAULT_PAGE_SIZE` env var > `default-page-size` config > hard-coded default (10). Validate range (1–200) and type (positive integer) with clear error
  messages. Export `DEFAULT_PAGE_SIZE` and `MAX_PAGE_SIZE` constants. Extend `generateInputSchemaAndDetails()` with optional `defaultPageSize` param; injects `default` into `page_size` query params that lack an OpenAPI-level default. Extend
  `extractToolsFromApi()` to accept and forward `defaultPageSize`. |
  | `src/config-utils.ts` | Add `"default-page-size"?: number` to the `AapMcpConfig` interface. |
  | `src/index.ts` | Resolve `defaultPageSize` at startup via `getDefaultPageSize(localConfig)`. Pass it through to `extractToolsFromApi()`. Log the resolved value and its source at startup. |
  | `aap-mcp.sample.yaml` | Document the `default-page-size` setting with priority rules and valid range. |
  | `src/config-utils.test.ts` | Add `getDefaultPageSize` test suite covering priority resolution (env var > config > hard-coded default) and validation (negative, zero, non-integer, exceeds max, boundary values). |
  | `src/extract-tools.test.ts` | Add test suites for default page_size injection via `extractToolsFromApi` and `generateInputSchemaAndDetails`. Edge cases: path params named `page_size` are not affected; tools without `page_size` are 
  unchanged. |

  ### Configuration
  
  **Config file** (`aap-mcp.yaml`):
  ```yaml
  default-page-size: 10    # integer, 1–200

  Environment variable (overrides config file):
  DEFAULT_PAGE_SIZE=25

  Priority: env var > config file > hard-coded default (10)

  ▎ Note: OpenAPI schema-level defaults always take precedence over this setting.

  Test plan
  
  - Unit tests pass: npm test (29 new test cases across 2 files)
  - Verify default page_size appears in startup log output
  - Set default-page-size: 50 in config, confirm list tools get page_size.default=50
  - Set DEFAULT_PAGE_SIZE=75 env var with config at 50, confirm env var wins
  - Confirm tools with existing OpenAPI page_size default retain their value
  - Confirm non-list tools (no page_size param) are unaffected
  - Verify invalid values (0, -1, 201, 'abc') produce clear error messages
