### PR TITLE
Add 24 controller tools to toolset config (ANSTRAT-1814)

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -76,6 +76,18 @@ toolsets:
     - controller.jobs_job_host_summaries_list
     - controller.workflow_jobs_list
     - controller.workflow_jobs_workflow_nodes_list
+    - controller.job_templates_create
+    - controller.schedules_create
+    - controller.projects_create
+    - controller.job_templates_credentials_create
+    - controller.job_templates_credentials_list
+    - controller.job_templates_survey_spec_create
+    - controller.job_templates_notification_templates_started_create
+    - controller.job_templates_notification_templates_success_create
+    - controller.job_templates_notification_templates_error_create
+    - controller.unified_job_templates_list
+    - controller.projects_playbooks_retrieve
+    - controller.workflow_job_template_nodes_credentials_list
 
   inventory_management:
     - controller.inventories_list
@@ -85,6 +97,12 @@ toolsets:
     - controller.hosts_variable_data_retrieve
     - controller.groups_list
     - controller.groups_create
+    - controller.inventories_create
+    - controller.hosts_create
+    - controller.inventory_sources_create
+    - controller.hosts_ansible_facts_retrieve
+    - controller.inventory_sources_list
+    - controller.inventories_inventory_sources_list
 
   system_monitoring:
     - controller.instance_groups_list
@@ -135,6 +153,7 @@ toolsets:
     - gateway.authenticators_destroy
     - gateway.authenticator_maps_list
     - gateway.authenticator_maps_create
+    - controller.users_activity_stream_list
     # - galaxy.api_galaxy__ui_v1_namespaces_list
     # - galaxy.api_galaxy__ui_v1_namespaces_create
     # - galaxy.repositories_ansible_ansible_list
@@ -155,6 +174,9 @@ toolsets:
     - controller.credential_types_retrieve
     - controller.credential_types_update
     - controller.credential_types_destroy
+    - controller.credentials_input_sources_create
+    - controller.job_templates_credentials_list
+    - controller.credential_input_sources_list
 
   platform_configuration:
     - controller.settings_list
@@ -175,6 +197,9 @@ toolsets:
     - controller.execution_environments_retrieve
     - controller.execution_environments_update
     - controller.execution_environments_destroy
+    - controller.organizations_execution_environments_create
+    - controller.organizations_instance_groups_create
+    - controller.organizations_galaxy_credentials_create
 
   # Categories below this comment have yet to be clarified/validated
   # Phase 3


### PR DESCRIPTION
## Summary

- Adds 24 net-new Controller tool entries to `aap-mcp.sample.yaml` across 5 toolsets per [ANSTRAT-1814](https://redhat.atlassian.net/browse/ANSTRAT-1814)
- All 24 operationIds validated against `data/controller-schema.json` — all exist with `x-ai-description` annotations
- Config-only change — no code modifications

### Toolset breakdown

| Toolset | New tools | Examples |
|---|---|---|
| `job_management` | +12 | `job_templates_create`, `schedules_create`, `projects_create`, survey spec, notification templates, credentials association |
| `inventory_management` | +6 | `inventories_create`, `hosts_create`, `inventory_sources_create`, cached facts, inventory source listing |
| `user_management` | +1 | `users_activity_stream_list` |
| `security_compliance` | +3 | `credentials_input_sources_create`, `credential_input_sources_list`, `job_templates_credentials_list` |
| `platform_configuration` | +3 | org-to-EE, org-to-instance-group, org-to-galaxy-credentials association |

`job_templates_credentials_list` appears in both `job_management` and `security_compliance` (cross-toolset, per ANSTRAT-1814).

### Note

- All `_create` tools require `allow_write_operations: true` in config
- `credential_types_create` and `authenticators_create` were already in existing toolsets — not re-added
- Galaxy (3 tools) and Lightspeed (1 tool) require code changes and will be handled in follow-up PRs

## Test plan

- [x] Verify new tools appear in `tools/list` for each toolset
- [x] Verify `allow_write_operations` gate works for new create tools

### Testing performed

Tested locally using `npm run simulate:mock-aap-server` + MCP server with `ALLOW_WRITE_OPERATIONS=true BASE_URL=http://localhost:8080`.

Confirmed all new tools appear in `tools/list` for each toolset:

| Toolset | Total tools | New tools present |
|---|---|---|
| `job_management` | 37 | all 12 |
| `inventory_management` | 13 | all 6 |
| `user_management` | 33 | 1 |
| `security_compliance` | 15 | all 3 |
| `platform_configuration` | 21 | all 3 |

Write-gating verified: restarting without `ALLOW_WRITE_OPERATIONS=true` correctly hides `_create` tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)