### PR TITLE
Add Galaxy content discovery toolset (AAP-81118)

### DIFF
--- a/aap-mcp.sample.yaml
+++ b/aap-mcp.sample.yaml
@@ -176,6 +176,11 @@ toolsets:
     - controller.execution_environments_update
     - controller.execution_environments_destroy
 
+  content_discovery:
+    - galaxy.ansible_content_collections_index
+    - galaxy.ansible_content_collections_index_versions_get_distro_base_pa
+    - galaxy.execution_environments_repositories_get_repositories
+
   # Categories below this comment have yet to be clarified/validated
   # Phase 3
   # event_management:

--- a/src/openapi-loader.test.ts
+++ b/src/openapi-loader.test.ts
@@ -216,20 +216,46 @@ describe("OpenAPI Loader", () => {
       expect(result).toBe(false);
       expect(mockTool.logs).toContainEqual({
         severity: "INFO",
-        msg: "tool ignored, name doesn't start with api_galaxy_v3",
+        msg: "tool ignored, name doesn't match allowed Galaxy prefixes",
       });
     });
 
-    it("should rename v3 tools correctly", () => {
-      const mockTool = createMockTool({
-        name: "api_galaxy_v3_collections_create",
-      });
+    it.each([
+      [
+        "api_galaxy_v3_",
+        "api_galaxy_v3_collections_create",
+        "collections_create",
+      ],
+      [
+        "v3_",
+        "v3_ansible_content_collections_index",
+        "ansible_content_collections_index",
+      ],
+    ])(
+      "should strip %s prefix and rename correctly",
+      (_prefix, input, expected) => {
+        const mockTool = createMockTool({ name: input });
 
-      const result = reformatGalaxyTool(mockTool);
+        const result = reformatGalaxyTool(mockTool);
 
-      expect(result).toBeTruthy();
-      if (result) {
-        expect(result.name).toBe("collections_create");
+        expect(result).toBeTruthy();
+        if (result) {
+          expect(result.name).toBe(expected);
+        }
+      },
+    );
+
+    it("should allow all three target v3_ Galaxy content tools", () => {
+      const toolNames = [
+        "v3_ansible_content_collections_index",
+        "v3_ansible_content_collections_index_versions_get_distro_base_pa",
+        "v3_execution_environments_repositories_get_repositories",
+      ];
+
+      for (const name of toolNames) {
+        const mockTool = createMockTool({ name });
+        const result = reformatGalaxyTool(mockTool);
+        expect(result).toBeTruthy();
       }
     });
   });

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -184,15 +184,18 @@ export const reformatGalaxyTool = (
     });
     return false;
   }
-  if (!tool.name.startsWith("api_galaxy_v3")) {
+  // Galaxy's OpenAPI schema uses inconsistent operationId prefixes unlike other services
+  const ALLOWED_GALAXY_PREFIXES = ["api_galaxy_v3_", "v3_"];
+  if (!ALLOWED_GALAXY_PREFIXES.some((prefix) => tool.name.startsWith(prefix))) {
     tool.logs.push({
       severity: "INFO",
-      msg: "tool ignored, name doesn't start with api_galaxy_v3",
+      msg: "tool ignored, name doesn't match allowed Galaxy prefixes",
     });
     return false;
   }
   const originalName = tool.name;
-  tool.name = tool.name.replace(/(api_galaxy_v3_|api_galaxy_|)(.+)/, "$2");
+  const prefixPattern = new RegExp(`^(${ALLOWED_GALAXY_PREFIXES.join("|")})`);
+  tool.name = tool.name.replace(prefixPattern, "");
   if (originalName !== tool.name) {
     tool.logs.push({
       severity: "WARN",


### PR DESCRIPTION
## Summary

- Updates `reformatGalaxyTool()` to accept `v3_` prefixed operationIds (previously only `api_galaxy_v3_` was allowed)
- Adds `content_discovery` toolset to `aap-mcp.sample.yaml` with 3 Galaxy tools
- Adds unit tests for the updated reformat function

### Tools added

| Tool | operationId | Path |
|---|---|---|
| Collections list | `v3_ansible_content_collections_index` | `GET /api/galaxy/v3/plugin/ansible/content/{distro_base_path}/collections/index/` |
| Collection versions | `v3_ansible_content_collections_index_versions_get_distro_base_pa` | `GET /api/galaxy/v3/plugin/ansible/content/{distro_base_path}/collections/index/{namespace}/{name}/versions/` |
| EE repositories list | `v3_execution_environments_repositories_get_repositories` | `GET /api/galaxy/v3/plugin/execution-environments/repositories/` |

### Code changes

- `src/openapi-loader.ts`: `reformatGalaxyTool()` now uses an `ALLOWED_GALAXY_PREFIXES` list (`api_galaxy_v3_`, `v3_`) for both the name filter and prefix stripping
- `src/openapi-loader.test.ts`: Added tests for `v3_` prefix stripping and all 3 target tools
- `aap-mcp.sample.yaml`: Added `content_discovery` toolset

### Testing performed

Tested locally with mock AAP server. All 3 tools appear in `tools/list` for the `content_discovery` toolset. Existing Galaxy tools unaffected — total tool count went from 125 to 128 (+3, no removals).

## Test plan

- [x] Unit tests pass (30/30)
- [x] New tools appear in `tools/list` for `content_discovery` toolset
- [x] Existing Galaxy tools still work (no regressions)
- [x] `_ui` path tools still filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)