### PR TITLE
Clamp int64 schema constraints to Number.MAX_SAFE_INTEGER

### DIFF
--- a/src/extract-tools.test.ts
+++ b/src/extract-tools.test.ts
@@ -5,6 +5,8 @@ import {
   AAPOperationObject,
   normalizeBoolean,
   shouldIncludeOperationForMcp,
+  clampNumericConstraints,
+  mapOpenApiSchemaToJsonSchema,
 } from "./extract-tools.js";
 import type { OpenAPIV3 } from "openapi-types";
 
@@ -1148,5 +1150,65 @@ describe("generateInputSchemaAndDetails with defaultPageSize", () => {
     const { inputSchema } = generateInputSchemaAndDetails(operation);
 
     expect((inputSchema as any).properties.page_size.default).toBeUndefined();
+  });
+});
+
+describe("clampNumericConstraints", () => {
+  it("should clamp int64-max to Number.MAX_SAFE_INTEGER", () => {
+    const schema: Record<string, any> = {
+      type: "number",
+      maximum: Number.MAX_SAFE_INTEGER + 10,
+      minimum: -(Number.MAX_SAFE_INTEGER + 10),
+    };
+    clampNumericConstraints(schema);
+    expect(schema.maximum).toBe(Number.MAX_SAFE_INTEGER);
+    expect(schema.minimum).toBe(-Number.MAX_SAFE_INTEGER);
+  });
+
+  it("should not modify values within safe range", () => {
+    const schema: Record<string, any> = {
+      type: "number",
+      maximum: 200,
+      minimum: 0,
+      maxLength: 255,
+    };
+    clampNumericConstraints(schema);
+    expect(schema.maximum).toBe(200);
+    expect(schema.minimum).toBe(0);
+    expect(schema.maxLength).toBe(255);
+  });
+
+  it("should skip non-numeric keys", () => {
+    const schema: Record<string, any> = {
+      type: "number",
+      maximum: "not a number",
+    };
+    clampNumericConstraints(schema);
+    expect(schema.maximum).toBe("not a number");
+  });
+});
+
+describe("mapOpenApiSchemaToJsonSchema", () => {
+  it("should clamp int64-max in nested properties", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        forks: {
+          type: "integer" as const,
+          maximum: Number.MAX_SAFE_INTEGER + 10,
+          minimum: 0,
+        },
+        timeout: {
+          type: "integer" as const,
+          maximum: Number.MAX_SAFE_INTEGER + 10,
+          minimum: -(Number.MAX_SAFE_INTEGER + 10),
+        },
+      },
+    };
+    const result = mapOpenApiSchemaToJsonSchema(schema) as any;
+    expect(result.properties.forks.maximum).toBe(Number.MAX_SAFE_INTEGER);
+    expect(result.properties.forks.minimum).toBe(0);
+    expect(result.properties.timeout.maximum).toBe(Number.MAX_SAFE_INTEGER);
+    expect(result.properties.timeout.minimum).toBe(-Number.MAX_SAFE_INTEGER);
   });
 });

--- a/src/extract-tools.ts
+++ b/src/extract-tools.ts
@@ -172,6 +172,35 @@ function generateOperationId(method: string, path: string): string {
   return name;
 }
 
+const NUMERIC_CONSTRAINT_KEYS = [
+  "maximum",
+  "minimum",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "maxLength",
+  "maxItems",
+  "maxProperties",
+  "minLength",
+  "minItems",
+  "minProperties",
+] as const;
+
+/**
+ * Clamps numeric JSON Schema constraints to Number.MAX_SAFE_INTEGER.
+ * OpenAPI specs generated from Python/Django use int64-max (2^63-1) which
+ * exceeds the safe integer range for JSON and causes API rejections.
+ */
+export function clampNumericConstraints(schema: Record<string, any>): void {
+  for (const key of NUMERIC_CONSTRAINT_KEYS) {
+    if (typeof schema[key] === "number") {
+      schema[key] = Math.max(
+        -Number.MAX_SAFE_INTEGER,
+        Math.min(Number.MAX_SAFE_INTEGER, schema[key]),
+      );
+    }
+  }
+}
+
 /**
  * Maps an OpenAPI schema to a JSON Schema with cycle protection.
  */
@@ -199,6 +228,7 @@ export function mapOpenApiSchemaToJsonSchema(
     const jsonSchema: any = { ...schema };
     // Convert integer type to number (JSON Schema compatible)
     if (schema.type === "integer") jsonSchema.type = "number";
+    clampNumericConstraints(jsonSchema);
     // Remove OpenAPI-specific properties that aren't in JSON Schema
     delete jsonSchema.nullable;
     delete jsonSchema.example;


### PR DESCRIPTION
## Summary
- Controller OpenAPI schema uses int64-max (`9223372036854775807`) for `maximum`/`minimum` on fields like `forks`, `timeout`, and `verbosity`
- After `oas.deref()` inlines these via `$ref` resolution, the values flow into tool `input_schema` and the Anthropic API rejects them with `int too big to convert`
- This was exposed by the new write/create controller tools (job_templates_create, inventory_sources_create, projects_create) which reference schemas containing these constraints
- Adds `clampNumericConstraints()` to cap all numeric JSON Schema constraints to `Number.MAX_SAFE_INTEGER` (2^53-1)

## Test plan
- [x] Unit tests for `clampNumericConstraints` (clamp, passthrough, non-numeric skip)
- [x] Unit test for `mapOpenApiSchemaToJsonSchema` with nested int64 properties
- [x] Full test suite passes (256/256)

🤖 Generated with [Claude Code](https://claude.com/claude-code)