### PR TITLE
Validate Issuer with normalized urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -682,8 +682,9 @@ async function main(): Promise<void> {
     `  Certificate validation: ${ignoreCertificateErrors ? "DISABLED" : "ENABLED"}`,
   );
   console.log(`  Metrics: ${enableMetrics ? "ENABLED" : "DISABLED"}`);
+
   console.log(
-    `  OAuth 2.1 discovery: ${isOAuth2Enabled() ? "ENABLED" : "DISABLED"}`,
+    `  OAuth 2.1 discovery: ${isOAuth2Enabled() ? "CONFIGURED" : "DISABLED"}`,
   );
 
   if (isOAuth2Enabled()) {
@@ -707,14 +708,16 @@ async function main(): Promise<void> {
         (name) => name !== "all",
       );
       app.use(createProtectedResourceRouter(oauth2Config, toolsetNames));
+      console.log(`  OAuth 2.1 discovery: ENABLED`);
       console.log(
         `  Authorization server: ${oauth2Config.authorizationServerUrl}`,
       );
       console.log(`  MCP Server URL: ${CONFIG.MCP_SERVER_URL}`);
       console.log("  OIDC Discovery: OK");
     } else {
+      console.log(`  OAuth 2.1 discovery: DISABLED`);
       console.warn(
-        `  WARNING: OAuth 2.1 discovery disabled — ${probeResult.reason}`,
+        `  WARNING: OAuth 2.1 discovery failed — ${probeResult.reason}`,
       );
       console.warn(
         "  Protected Resource Metadata and WWW-Authenticate headers will not be served.",

--- a/src/oauth2/protected-resource-metadata.test.ts
+++ b/src/oauth2/protected-resource-metadata.test.ts
@@ -15,6 +15,7 @@ import {
   isOAuth2Enabled,
   probeOidcDiscovery,
   resolveResourceUrl,
+  validateIssuerUrl,
   type ProtectedResourceConfig,
 } from "./protected-resource-metadata.js";
 
@@ -180,6 +181,42 @@ describe("probeOidcDiscovery", () => {
     }
   });
 
+  it("succeeds when issuer matches after port normalization", async () => {
+    const baseUrl = `http://localhost:${mockPort}`;
+    responseBody = {
+      ...responseBody,
+      issuer: `http://localhost:${mockPort}/o`,
+    };
+
+    const result = await probeOidcDiscovery(baseUrl, 5);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails when metadata issuer is not a valid URL", async () => {
+    const baseUrl = `http://localhost:${mockPort}`;
+    responseBody = { ...responseBody, issuer: "not-a-url" };
+
+    const result = await probeOidcDiscovery(baseUrl, 5);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("not a valid URL");
+    }
+  });
+
+  it("fails when metadata issuer uses non-http protocol", async () => {
+    const baseUrl = `http://localhost:${mockPort}`;
+    responseBody = { ...responseBody, issuer: "ftp://example.com/o" };
+
+    const result = await probeOidcDiscovery(baseUrl, 5);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("http or https");
+    }
+  });
+
   it("fails when issuer does not match", async () => {
     const baseUrl = `http://localhost:${mockPort}`;
     responseBody = { ...responseBody, issuer: "https://wrong-issuer.com/o" };
@@ -283,6 +320,60 @@ describe("probeOidcDiscovery", () => {
       }
     } finally {
       await new Promise<void>((resolve) => slowServer.close(() => resolve()));
+    }
+  });
+
+  it("fails when base URL is not a valid URL", async () => {
+    const result = await probeOidcDiscovery("not-a-url", 5);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("Expected issuer");
+      expect(result.reason).toContain("not a valid URL");
+    }
+  });
+});
+
+// --- validateIssuerUrl ---
+
+describe("validateIssuerUrl", () => {
+  it.each([
+    ["https://example.com/o", "https://example.com/o", "valid https URL"],
+    ["http://localhost/o", "http://localhost/o", "valid http URL"],
+    [
+      "https://example.com:443/o",
+      "https://example.com/o",
+      "strips default https port 443",
+    ],
+    [
+      "http://localhost:80/o",
+      "http://localhost/o",
+      "strips default http port 80",
+    ],
+    [
+      "https://example.com:8443/o",
+      "https://example.com:8443/o",
+      "preserves non-default ports",
+    ],
+    [
+      "https://example.com/o/",
+      "https://example.com/o",
+      "strips trailing slashes",
+    ],
+  ])("normalizes %s → %s (%s)", (input, expected) => {
+    const result = validateIssuerUrl(input, "Test");
+    expect(result).toEqual({ ok: true, normalized: expected });
+  });
+
+  it.each([
+    ["not-a-url", "Test", "not a valid URL", "invalid URL"],
+    ["ftp://example.com/o", "Test", "http or https", "non-http(s) protocol"],
+    ["bad", "Metadata issuer", "Metadata issuer", "includes label in reason"],
+  ])("rejects %s — %s (%s)", (input, label, expectedReason) => {
+    const result = validateIssuerUrl(input, label);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain(expectedReason);
     }
   });
 });

--- a/src/oauth2/protected-resource-metadata.ts
+++ b/src/oauth2/protected-resource-metadata.ts
@@ -38,6 +38,28 @@ function stripTrailingSlashes(url: string): string {
   return url.slice(0, end);
 }
 
+export function validateIssuerUrl(
+  raw: string,
+  label: string,
+): { ok: true; normalized: string } | { ok: false; reason: string } {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, reason: `${label} is not a valid URL: "${raw}"` };
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return {
+      ok: false,
+      reason: `${label} must use http or https, got "${url.protocol}"`,
+    };
+  }
+  return {
+    ok: true,
+    normalized: stripTrailingSlashes(url.origin + url.pathname),
+  };
+}
+
 // --- Configuration ---
 
 export function isOAuth2Enabled(): boolean {
@@ -79,7 +101,15 @@ export async function probeOidcDiscovery(
   timeoutSeconds: number,
 ): Promise<{ ok: true; issuer: string } | { ok: false; reason: string }> {
   const discoveryUrl = deriveOidcDiscoveryUrl(baseUrl);
-  const expectedIssuer = deriveAuthorizationServerUrl(baseUrl);
+  const expectedIssuerRaw = deriveAuthorizationServerUrl(baseUrl);
+
+  const expectedResult = validateIssuerUrl(
+    expectedIssuerRaw,
+    "Expected issuer",
+  );
+  if (!expectedResult.ok) {
+    return expectedResult;
+  }
 
   try {
     const response = await fetch(discoveryUrl, {
@@ -108,10 +138,20 @@ export async function probeOidcDiscovery(
       };
     }
 
-    if (metadata.issuer !== expectedIssuer) {
+    const metadataResult = validateIssuerUrl(
+      metadata.issuer,
+      "Metadata issuer",
+    );
+    if (!metadataResult.ok) {
+      return metadataResult;
+    }
+
+    // Intentional: normalized comparison instead of RFC 8414 exact-string match
+    // to tolerate default-port differences between AAP gateway and base URL config.
+    if (metadataResult.normalized !== expectedResult.normalized) {
       return {
         ok: false,
-        reason: `Issuer mismatch: expected "${expectedIssuer}", got "${metadata.issuer}"`,
+        reason: `Issuer mismatch: expected "${expectedIssuerRaw}", got "${metadata.issuer}"`,
       };
     }
 


### PR DESCRIPTION
Validate Issuer with normalized urls

Validate Issuer with normalized urls, one irl can use default port 443 or 80 while the not its still a valid urls , also the urls has to valid urls

Issue: https://redhat.atlassian.net/browse/AAP-80504

Co-Authored-By: Claude Code <noreply@anthropic.com>