### PR TITLE
Add DEBUG_HTTP option to make inbound and outbound requests visible

### DIFF
--- a/src/http-debug.test.ts
+++ b/src/http-debug.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { describeInboundAuth, extractMcpRpcMethod } from "./http-debug.js";
+
+describe("describeInboundAuth", () => {
+  it("reports missing auth", () => {
+    expect(describeInboundAuth(undefined)).toBe("missing");
+  });
+
+  it("reports empty bearer token", () => {
+    expect(describeInboundAuth("Bearer ")).toBe("Bearer(empty)");
+  });
+
+  it("reports bearer token length without exposing value", () => {
+    expect(describeInboundAuth("Bearer secret-token")).toBe("Bearer(12 chars)");
+  });
+
+  it("reports non-bearer schemes", () => {
+    expect(describeInboundAuth("Basic dXNlcjpwYXNz")).toBe("present(Basic)");
+  });
+});
+
+describe("extractMcpRpcMethod", () => {
+  it("extracts jsonrpc method from request body", () => {
+    expect(
+      extractMcpRpcMethod({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+      }),
+    ).toBe("initialize");
+  });
+
+  it("returns undefined for non-object bodies", () => {
+    expect(extractMcpRpcMethod(null)).toBeUndefined();
+    expect(extractMcpRpcMethod("initialize")).toBeUndefined();
+  });
+});

--- a/src/http-debug.ts
+++ b/src/http-debug.ts
@@ -1,0 +1,17 @@
+export const describeInboundAuth = (authHeader: string | undefined): string => {
+  if (!authHeader) return "missing";
+  if (authHeader.startsWith("Bearer ")) {
+    const tokenLength = authHeader.length - 7;
+    return tokenLength === 0 ? "Bearer(empty)" : `Bearer(${tokenLength} chars)`;
+  }
+  const scheme = authHeader.split(" ")[0] || "unknown";
+  return `present(${scheme})`;
+};
+
+export const extractMcpRpcMethod = (body: unknown): string | undefined => {
+  if (body && typeof body === "object" && "method" in body) {
+    const method = (body as { method?: unknown }).method;
+    return typeof method === "string" ? method : undefined;
+  }
+  return undefined;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,9 @@ const allowWriteOperations = getBooleanConfig(
   localConfig.allow_write_operations,
 );
 
+// When true, logs every outbound HTTP request URL+method and non-OK response bodies
+const debugHttp = getBooleanConfig("DEBUG_HTTP", false);
+
 // Initialize allowed operations list based on configuration
 const allowedOperations = allowWriteOperations
   ? ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
@@ -114,6 +117,12 @@ const servicesConfig = localConfig.services || [];
 const getTimestamp = (): string => {
   return new Date().toISOString().split(".")[0] + "Z";
 };
+
+if (debugHttp) {
+  console.log(
+    `${getTimestamp()} DEBUG_HTTP enabled — outbound request URLs and non-OK response bodies will be logged`,
+  );
+}
 
 // Configure HTTPS certificate validation globally
 if (ignoreCertificateErrors) {
@@ -376,15 +385,24 @@ const executeToolRequest = async (
   const startTime = Date.now();
   const toolToolset = getToolsetForTool(tool.name);
   let response: Response | undefined;
+  let result: unknown;
+  let fullUrl = "";
 
   try {
     const url = buildToolUrl(tool, args);
     const requestOptions = buildRequestOptions(tool, args, ctx.token);
+    fullUrl = `${CONFIG.BASE_URL}${url}`;
 
-    response = await fetch(`${CONFIG.BASE_URL}${url}`, requestOptions);
+    if (debugHttp) {
+      console.log(
+        `${getTimestamp()} [DEBUG_HTTP] ${requestOptions.method} ${fullUrl}`,
+      );
+    }
+
+    response = await fetch(fullUrl, requestOptions);
 
     const contentType = response.headers.get("content-type");
-    const result = contentType?.includes("application/json")
+    result = contentType?.includes("application/json")
       ? await response.json()
       : await response.text();
 
@@ -397,6 +415,19 @@ const executeToolRequest = async (
       { cause: error },
     );
   } finally {
+    // Always surface the full URL on error responses so 404/5xx are traceable
+    if (response && !response.ok) {
+      console.error(
+        `${getTimestamp()} [toolset:${toolToolset}] ${tool.name} failed: ${response.status} ${response.statusText} — URL: ${fullUrl}`,
+      );
+      if (debugHttp && result !== undefined) {
+        const bodySnippet = JSON.stringify(result).slice(0, 500);
+        console.error(
+          `${getTimestamp()} [DEBUG_HTTP] response body (first 500 chars): ${bodySnippet}`,
+        );
+      }
+    }
+
     trackToolExecution(
       tool,
       toolToolset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,10 @@ import {
   type ProtectedResourceConfig,
   type Rfc6750Error,
 } from "./oauth2/protected-resource-metadata.js";
+import {
+  describeInboundAuth,
+  extractMcpRpcMethod,
+} from "./http-debug.js";
 
 // Load environment variables
 config();
@@ -95,7 +99,7 @@ const allowWriteOperations = getBooleanConfig(
   localConfig.allow_write_operations,
 );
 
-// When true, logs every outbound HTTP request URL+method and non-OK response bodies
+// When true, logs inbound MCP requests and outbound AAP HTTP traffic
 const debugHttp = getBooleanConfig("DEBUG_HTTP", false);
 
 // Initialize allowed operations list based on configuration
@@ -118,9 +122,15 @@ const getTimestamp = (): string => {
   return new Date().toISOString().split(".")[0] + "Z";
 };
 
+const debugLog = (message: string): void => {
+  if (debugHttp) {
+    console.log(`${getTimestamp()} [DEBUG_HTTP] ${message}`);
+  }
+};
+
 if (debugHttp) {
   console.log(
-    `${getTimestamp()} DEBUG_HTTP enabled — outbound request URLs and non-OK response bodies will be logged`,
+    `${getTimestamp()} DEBUG_HTTP enabled — inbound MCP requests and outbound AAP HTTP traffic will be logged`,
   );
 }
 
@@ -182,7 +192,6 @@ const validateToken = async (bearerToken: string): Promise<UserInfo> => {
       return {};
     }
   } catch (error) {
-    console.error(`${getTimestamp()} Token validation failed:`, error);
     throw new Error(
       `Token validation failed: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },
@@ -393,11 +402,7 @@ const executeToolRequest = async (
     const requestOptions = buildRequestOptions(tool, args, ctx.token);
     fullUrl = `${CONFIG.BASE_URL}${url}`;
 
-    if (debugHttp) {
-      console.log(
-        `${getTimestamp()} [DEBUG_HTTP] ${requestOptions.method} ${fullUrl}`,
-      );
-    }
+    debugLog(`outbound ${requestOptions.method} ${fullUrl}`);
 
     response = await fetch(fullUrl, requestOptions);
 
@@ -420,11 +425,9 @@ const executeToolRequest = async (
       console.error(
         `${getTimestamp()} [toolset:${toolToolset}] ${tool.name} failed: ${response.status} ${response.statusText} — URL: ${fullUrl}`,
       );
-      if (debugHttp && result !== undefined) {
+      if (result !== undefined) {
         const bodySnippet = JSON.stringify(result).slice(0, 500);
-        console.error(
-          `${getTimestamp()} [DEBUG_HTTP] response body (first 500 chars): ${bodySnippet}`,
-        );
+        debugLog(`outbound response body (first 500 chars): ${bodySnippet}`);
       }
     }
 
@@ -508,6 +511,9 @@ app.use((req, res, next) => {
     // Reject requests without session ID or Authorization header immediately
     // This prevents expensive JSON parsing and session creation for unauthenticated requests
     if (!sessionId && !authHeader) {
+      debugLog(
+        `inbound ${req.method} ${req.path} auth=missing session=no → 401 (early reject: no credentials)`,
+      );
       applyWwwAuthenticate(res, req.path);
       res.status(401).json({
         jsonrpc: "2.0",
@@ -519,6 +525,10 @@ app.use((req, res, next) => {
       });
       return;
     }
+
+    debugLog(
+      `inbound ${req.method} ${req.path} auth=${describeInboundAuth(authHeader as string | undefined)} session=${sessionId ? "yes" : "no"} (passed early auth)`,
+    );
   }
 
   next();
@@ -552,7 +562,9 @@ const authenticateRequest = async (
   try {
     userInfo = await validateToken(token);
   } catch (error) {
-    console.error(`${getTimestamp()} Token validation failed:`, error);
+    debugLog(
+      `token validation failed for toolset=${toolset}: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return { ok: false, reason: "invalid-token" };
   }
 
@@ -595,13 +607,29 @@ const mcpPostHandler = async (
   res: express.Response,
   toolset: string = "all",
 ) => {
-  console.log(`${getTimestamp()} Received MCP request`);
+  const mcpMethod = extractMcpRpcMethod(req.body);
+  const authHeader = (req.headers["authorization"] ||
+    req.headers["x-authorization"]) as string | undefined;
+  debugLog(
+    `inbound ${req.method} ${req.path} toolset=${toolset} mcp=${mcpMethod ?? "unknown"} auth=${describeInboundAuth(authHeader)} ua=${(req.headers["user-agent"] as string) || "unknown"}`,
+  );
+
+  if (debugHttp) {
+    res.on("finish", () => {
+      debugLog(
+        `inbound ${req.method} ${req.path} toolset=${toolset} mcp=${mcpMethod ?? "unknown"} → ${res.statusCode}`,
+      );
+    });
+  }
 
   try {
     // Authenticate every request
     const authResult = await authenticateRequest(req, toolset);
     if (!authResult.ok) {
       const isInvalidToken = authResult.reason === "invalid-token";
+      debugLog(
+        `inbound ${req.method} ${req.path} toolset=${toolset} mcp=${mcpMethod ?? "unknown"} → 401 (${isInvalidToken ? "invalid token" : "bearer token required"})`,
+      );
       applyWwwAuthenticate(
         res,
         req.path,
@@ -621,6 +649,9 @@ const mcpPostHandler = async (
     }
 
     const ctx = authResult.ctx;
+    debugLog(
+      `inbound ${req.method} ${req.path} toolset=${toolset} mcp=${mcpMethod ?? "unknown"} auth=ok userType=${ctx.userType}`,
+    );
 
     // Create a fresh stateless transport for each request
     const transport = new StreamableHTTPServerTransport({
@@ -668,17 +699,11 @@ app.post("/mcp", (req, res) => mcpPostHandler(req, res));
 
 app.post("/:toolset/mcp", (req, res) => {
   const toolset = req.params.toolset;
-  console.log(
-    `${getTimestamp()} Toolset-specific POST request for toolset: ${toolset}`,
-  );
   return mcpPostHandler(req, res, toolset);
 });
 
 app.post("/mcp/:toolset", (req, res) => {
   const toolset = req.params.toolset;
-  console.log(
-    `${getTimestamp()} Toolset-specific POST request for toolset: ${toolset}`,
-  );
   return mcpPostHandler(req, res, toolset);
 });
 
@@ -739,6 +764,7 @@ async function main(): Promise<void> {
     `  Certificate validation: ${ignoreCertificateErrors ? "DISABLED" : "ENABLED"}`,
   );
   console.log(`  Metrics: ${enableMetrics ? "ENABLED" : "DISABLED"}`);
+  console.log(`  HTTP debug logging: ${debugHttp ? "ENABLED" : "DISABLED"}`);
 
   console.log(
     `  OAuth 2.1 discovery: ${isOAuth2Enabled() ? "CONFIGURED" : "DISABLED"}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,11 +192,22 @@ const validateToken = async (bearerToken: string): Promise<UserInfo> => {
       return {};
     }
   } catch (error) {
+    console.error("Token validation failed:", error);
     throw new Error(
       `Token validation failed: ${error instanceof Error ? error.message : String(error)}`,
       { cause: error },
     );
   }
+};
+
+// Normalize auth header to handle Express returning string[] for duplicate headers
+const normalizeAuthHeader = (
+  authOrXAuth: string | string[] | undefined,
+): string | undefined => {
+  if (!authOrXAuth) return undefined;
+  // If Express received duplicate headers, it returns string[]
+  // Take the first value to prevent crashes in downstream code
+  return Array.isArray(authOrXAuth) ? authOrXAuth[0] : authOrXAuth;
 };
 
 // Determine user toolset based on toolset name
@@ -505,8 +516,9 @@ app.use((req, res, next) => {
   // Only apply to POST requests to MCP endpoints
   if (req.method === "POST" && req.path.includes("/mcp")) {
     const sessionId = req.headers["mcp-session-id"];
-    const authHeader =
-      req.headers["authorization"] || req.headers["x-authorization"];
+    const authHeader = normalizeAuthHeader(
+      req.headers["authorization"] || req.headers["x-authorization"],
+    );
 
     // Reject requests without session ID or Authorization header immediately
     // This prevents expensive JSON parsing and session creation for unauthenticated requests
@@ -551,8 +563,9 @@ const authenticateRequest = async (
   | { ok: false; reason: "no-token" }
   | { ok: false; reason: "invalid-token" }
 > => {
-  const authHeader = (req.headers["authorization"] ||
-    req.headers["x-authorization"]) as string;
+  const authHeader = normalizeAuthHeader(
+    req.headers["authorization"] || req.headers["x-authorization"],
+  );
   const token = extractBearerToken(authHeader);
   if (!token) {
     return { ok: false, reason: "no-token" };
@@ -608,8 +621,9 @@ const mcpPostHandler = async (
   toolset: string = "all",
 ) => {
   const mcpMethod = extractMcpRpcMethod(req.body);
-  const authHeader = (req.headers["authorization"] ||
-    req.headers["x-authorization"]) as string | undefined;
+  const authHeader = normalizeAuthHeader(
+    req.headers["authorization"] || req.headers["x-authorization"],
+  );
   debugLog(
     `inbound ${req.method} ${req.path} toolset=${toolset} mcp=${mcpMethod ?? "unknown"} auth=${describeInboundAuth(authHeader)} ua=${(req.headers["user-agent"] as string) || "unknown"}`,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,7 @@ import {
   type ProtectedResourceConfig,
   type Rfc6750Error,
 } from "./oauth2/protected-resource-metadata.js";
-import {
-  describeInboundAuth,
-  extractMcpRpcMethod,
-} from "./http-debug.js";
+import { describeInboundAuth, extractMcpRpcMethod } from "./http-debug.js";
 
 // Load environment variables
 config();


### PR DESCRIPTION
This Change provides a DEBUG_HTTP option to make inbound and outbound requests visible.

without `DEBUG_HTTP=false`
```shell
2026-07-17T06:21:30Z [toolset:job_management] jobs_list → 200 OK (698ms)
2026-07-17T06:23:20Z [toolset:job_management] jobs_retrieve → 200 OK (619ms)
2026-07-17T06:23:21Z [toolset:job_management] jobs_retrieve → 200 OK (227ms)
2026-07-17T06:23:31Z [toolset:job_management] jobs_stdout_retrieve → 406 Not Acceptable (265ms)
2026-07-17T06:23:31Z [toolset:job_management] jobs_stdout_retrieve failed: 406 Not Acceptable — URL: https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/6723/stdout/?format=txt
2026-07-17T06:23:40Z [toolset:job_management] jobs_stdout_retrieve → 406 Not Acceptable (192ms)
2026-07-17T06:23:40Z [toolset:job_management] jobs_stdout_retrieve failed: 406 Not Acceptable — URL: https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/6001/stdout/?format=txt
2026-07-17T06:24:06Z [toolset:job_management] jobs_stdout_retrieve → 200 OK (274ms)
2026-07-17T06:24:08Z [toolset:job_management] jobs_stdout_retrieve → 200 OK (183ms)
```

with `HTTP_DEBUG=true`
```shell
2026-07-17T06:27:44Z [DEBUG_HTTP] inbound POST /job_management/mcp auth=Bearer(30 chars) session=no (passed early auth)
2026-07-17T06:27:44Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=Bearer(30 chars) ua=curl/8.7.1
(node:1) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
2026-07-17T06:27:44Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=ok userType=external
2026-07-17T06:27:44Z [DEBUG_HTTP] outbound GET https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/6725/
2026-07-17T06:27:44Z [toolset:job_management] jobs_retrieve → 200 OK (247ms)
2026-07-17T06:27:44Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call → 200
2026-07-17T06:27:46Z [DEBUG_HTTP] inbound POST /job_management/mcp auth=Bearer(30 chars) session=no (passed early auth)
2026-07-17T06:27:46Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=Bearer(30 chars) ua=curl/8.7.1
2026-07-17T06:27:46Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=ok userType=external
2026-07-17T06:27:46Z [DEBUG_HTTP] outbound GET https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/5500/
2026-07-17T06:27:46Z [toolset:job_management] jobs_retrieve → 200 OK (199ms)
2026-07-17T06:27:46Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call → 200
2026-07-17T06:27:48Z [DEBUG_HTTP] inbound POST /job_management/mcp auth=Bearer(30 chars) session=no (passed early auth)
2026-07-17T06:27:48Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=Bearer(30 chars) ua=curl/8.7.1
2026-07-17T06:27:48Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=ok userType=external
2026-07-17T06:27:48Z [DEBUG_HTTP] outbound GET https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/6725/stdout/?format=json
2026-07-17T06:27:48Z [toolset:job_management] jobs_stdout_retrieve → 200 OK (174ms)
2026-07-17T06:27:48Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call → 200
2026-07-17T06:27:50Z [DEBUG_HTTP] inbound POST /job_management/mcp auth=Bearer(30 chars) session=no (passed early auth)
2026-07-17T06:27:50Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=Bearer(30 chars) ua=curl/8.7.1
2026-07-17T06:27:50Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call auth=ok userType=external
2026-07-17T06:27:50Z [DEBUG_HTTP] outbound GET https://lab-aap-26-containerized.crazy.lab/api/controller/v2/jobs/5500/stdout/?format=json
2026-07-17T06:27:51Z [toolset:job_management] jobs_stdout_retrieve → 200 OK (215ms)
2026-07-17T06:27:51Z [DEBUG_HTTP] inbound POST /job_management/mcp toolset=job_management mcp=tools/call → 200
```