### PR TITLE
Support Controller-only deployments (no Platform Gateway)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,14 +146,25 @@ const extractBearerToken = (
 };
 
 // Validate authorization token
-const validateToken = async (bearerToken: string): Promise<UserInfo> => {
+export const validateToken = async (
+  bearerToken: string,
+): Promise<UserInfo> => {
   try {
-    const response = await fetch(`${CONFIG.BASE_URL}/api/gateway/v1/me/`, {
-      headers: {
-        Authorization: `Bearer ${bearerToken}`,
-        Accept: "application/json",
-      },
+    const headers = {
+      Authorization: `Bearer ${bearerToken}`,
+      Accept: "application/json",
+    };
+    let response = await fetch(`${CONFIG.BASE_URL}/api/gateway/v1/me/`, {
+      headers,
     });
+
+    // Controller-only deployments without Platform Gateway expose the same
+    // token-scoped identity document at the legacy Controller endpoint.
+    // Fall back only when Gateway is absent (404); never mask an auth or
+    // TLS error behind the fallback.
+    if (response.status === 404) {
+      response = await fetch(`${CONFIG.BASE_URL}/api/v2/me/`, { headers });
+    }
 
     if (!response.ok) {
       throw new Error(

--- a/src/openapi-loader.test.ts
+++ b/src/openapi-loader.test.ts
@@ -345,6 +345,55 @@ describe("OpenAPI Loader", () => {
     });
   });
 
+  describe("reformatControllerTool with CONTROLLER_LEGACY_PATHS", () => {
+    const ORIGINAL_ENV = process.env.CONTROLLER_LEGACY_PATHS;
+
+    afterEach(() => {
+      if (ORIGINAL_ENV === undefined) {
+        delete process.env.CONTROLLER_LEGACY_PATHS;
+      } else {
+        process.env.CONTROLLER_LEGACY_PATHS = ORIGINAL_ENV;
+      }
+    });
+
+    it("should keep legacy /api/v2 paths when CONTROLLER_LEGACY_PATHS is true", () => {
+      process.env.CONTROLLER_LEGACY_PATHS = "true";
+      const mockTool = createMockTool({
+        name: "api_jobs_list",
+        pathTemplate: "/api/v2/jobs/",
+      });
+
+      const result = reformatControllerTool(mockTool);
+
+      expect(result.name).toBe("jobs_list");
+      expect(result.pathTemplate).toBe("/api/v2/jobs/");
+    });
+
+    it("should rewrite to gateway paths when CONTROLLER_LEGACY_PATHS is unset", () => {
+      delete process.env.CONTROLLER_LEGACY_PATHS;
+      const mockTool = createMockTool({
+        name: "api_jobs_list",
+        pathTemplate: "/api/v2/jobs/",
+      });
+
+      const result = reformatControllerTool(mockTool);
+
+      expect(result.pathTemplate).toBe("/api/controller/v2/jobs/");
+    });
+
+    it("should rewrite to gateway paths when CONTROLLER_LEGACY_PATHS is not exactly true", () => {
+      process.env.CONTROLLER_LEGACY_PATHS = "1";
+      const mockTool = createMockTool({
+        name: "api_jobs_list",
+        pathTemplate: "/api/v2/jobs/",
+      });
+
+      const result = reformatControllerTool(mockTool);
+
+      expect(result.pathTemplate).toBe("/api/controller/v2/jobs/");
+    });
+  });
+
   describe("reformatLightspeedTool", () => {
     it("should prepend /api/lightspeed/v1 to path template and rename mapped tools", () => {
       const mockTool = createMockTool({

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -243,10 +243,15 @@ export const reformatLightspeedTool = (
 export const reformatControllerTool = (
   tool: AAPMcpToolDefinition,
 ): AAPMcpToolDefinition => {
-  tool.pathTemplate = tool.pathTemplate?.replace(
-    "/api/v2",
-    "/api/controller/v2",
-  );
+  // Controller-only deployments without Platform Gateway keep the legacy
+  // /api/v2 paths. Set CONTROLLER_LEGACY_PATHS=true to skip the gateway
+  // rewrite; the default (gateway paths) is unchanged.
+  if (process.env.CONTROLLER_LEGACY_PATHS !== "true") {
+    tool.pathTemplate = tool.pathTemplate?.replace(
+      "/api/v2",
+      "/api/controller/v2",
+    );
+  }
 
   // Remove api_ prefix if it exists (backwards compatibility),
   // then always prepend controller.

--- a/src/validate-token.test.ts
+++ b/src/validate-token.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// index.ts reads aap-mcp.yaml from cwd at import time; mock fs so the module
+// loads with a minimal valid config (no services -> no spec fetches).
+vi.mock("fs", async () => {
+  const actual = await vi.importActual("fs");
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => "toolsets: {}\nservices: []\n"),
+    writeFileSync: vi.fn(),
+  };
+});
+
+vi.mock("express", () => {
+  const mockApp = {
+    use: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+    listen: vi.fn(),
+  };
+  const express = vi.fn(() => mockApp);
+  express.json = vi.fn();
+  return { default: express };
+});
+
+vi.mock("cors", () => ({ default: vi.fn() }));
+vi.mock("dotenv", () => ({ config: vi.fn() }));
+
+import { validateToken } from "./index.js";
+
+describe("validateToken", () => {
+  const makeResponse = (status: number, body: unknown = {}) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: async () => body,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("accepts a valid token via the gateway identity endpoint", async () => {
+    (global.fetch as any).mockResolvedValueOnce(
+      makeResponse(200, { results: [{ email: "a@b.c" }] }),
+    );
+
+    await expect(validateToken("good-token")).resolves.toBeTruthy();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect((global.fetch as any).mock.calls[0][0]).toContain(
+      "/api/gateway/v1/me/",
+    );
+  });
+
+  it("falls back to the controller identity endpoint only on gateway 404", async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(makeResponse(404))
+      .mockResolvedValueOnce(makeResponse(200, { results: [{}] }));
+
+    await expect(validateToken("good-token")).resolves.toBeTruthy();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect((global.fetch as any).mock.calls[1][0]).toContain("/api/v2/me/");
+  });
+
+  it("does not fall back on gateway 401", async () => {
+    (global.fetch as any).mockResolvedValueOnce(makeResponse(401));
+
+    await expect(validateToken("bad-token")).rejects.toThrow();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when both gateway and controller identity endpoints 404", async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(makeResponse(404))
+      .mockResolvedValueOnce(makeResponse(404));
+
+    await expect(validateToken("any-token")).rejects.toThrow();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Two small, default-preserving changes that let the server run against AAP Controller deployments that have **no Platform Gateway** (standalone Controller):

1. **Token validation fallback** — `validateToken` retries the same bearer at `/api/v2/me/` only when `/api/gateway/v1/me/` returns 404.
2. **Opt-out of the gateway path rewrite** — `reformatControllerTool` skips the `/api/v2` → `/api/controller/v2` rewrite when `CONTROLLER_LEGACY_PATHS=true`.

## Problem

On a Controller-only deployment (standalone Controller 4.5.x, no Platform Gateway):

- Every MCP request failed token validation: `/api/gateway/v1/me/` → 404 → `Authentication failed: 404`, even for valid tokens.
- With validation patched locally, **every controller tool** then returned the API's 404 body (`{"detail": "The requested resource could not be found."}`), because `reformatControllerTool` unconditionally rewrites `/api/v2` → `/api/controller/v2` — a path shape that only exists behind the Platform Gateway.

Verified against a live Controller-only instance (Controller 4.5.19):

| Path | Result |
|---|---|
| `/api/v2/ping/` | 200 |
| `/api/controller/v2/ping/` | 404 |
| `/api/v2/me/` | 200 |
| `/api/v2/instances/` | 200 |

## Changes

- `src/index.ts`: on a 404 from `/api/gateway/v1/me/`, retry the same bearer against `/api/v2/me/`. Auth failures (401/403), TLS, and transport errors remain fail-closed and never trigger the fallback. `validateToken` is exported, matching the existing `buildToolUrl` / `buildRequestOptions` test-export pattern.
- `src/openapi-loader.ts`: the `/api/v2` → `/api/controller/v2` rewrite is skipped when `CONTROLLER_LEGACY_PATHS=true`. Unset or any other value keeps the current gateway-path behavior, so existing gateway deployments are unaffected.

## Tests

- New `src/validate-token.test.ts` (4 tests): gateway success, 404→fallback success, 401 no-fallback, double-404 rejection. The file mocks the module's import-time dependencies (`fs`, `express`, `cors`, `dotenv`) so it loads in isolation.
- `src/openapi-loader.test.ts`: 3 new flag tests (`CONTROLLER_LEGACY_PATHS` set to `"true"`, unset, and non-`"true"`).
- `npx vitest run src/openapi-loader.test.ts src/validate-token.test.ts` → **40/40 pass**.

## Notes

- Pre-existing and unrelated: `src/index.test.ts` currently fails at import on `main` (`ENOENT: aap-mcp.yaml` — the module-level `loadConfig()` reads from cwd). Not caused by this PR and left untouched; happy to send a follow-up that wires `tests/setup.ts` (or a fixture config) into `vitest.config.ts` if desired.
- Related API-topology discussion: #145.