### PR TITLE
Upgrade SonarSource/sonarqube-scan-action to v6 (security fix)

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -77,7 +77,7 @@ jobs:
       - name: SonarCloud Scan
         # Skip for fork PRs where secrets are not available
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets[format('{0}', vars.SONAR_TOKEN_SECRET_NAME)] }}


### PR DESCRIPTION
Fixes Dependabot alert 45 and 46: argument injection vulnerability in sonarqube-scan-action versions >= 4.0.0, < 6.0.0.

https://github.com/ansible/aap-mcp-server/security/dependabot/45

https://github.com/ansible/aap-mcp-server/security/dependabot/46